### PR TITLE
Read token from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ VERSION
 ```
 
 A valid Fastly API `-token` is mandatory. [See this link][token] for information
-on creating API tokens. Token can be provided via environment variable
+on creating API tokens. The token can also be provided via the environment variable
 `FASTLY_API_TOKEN`.
 
 Optional `-service` IDs can be specified to limit monitoring to specific

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ VERSION
 ```
 
 A valid Fastly API `-token` is mandatory. [See this link][token] for information
-on creating API tokens. 
+on creating API tokens. Token can be provided via environment variable `FASTLY_API_TOKEN`.
 
 Optional `-service` IDs can be specified to limit monitoring to specific
-services. Service IDs are available at the top of your [Fastly dashboard][db]. 
+services. Service IDs are available at the top of your [Fastly dashboard][db].
 
 [token]: https://docs.fastly.com/guides/account-management-and-security/using-api-tokens#creating-api-tokens
 [db]: https://manage.fastly.com/services/all

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ VERSION
 ```
 
 A valid Fastly API `-token` is mandatory. [See this link][token] for information
-on creating API tokens. Token can be provided via environment variable `FASTLY_API_TOKEN`.
+on creating API tokens. Token can be provided via environment variable
+`FASTLY_API_TOKEN`.
 
 Optional `-service` IDs can be specified to limit monitoring to specific
 services. Service IDs are available at the top of your [Fastly dashboard][db].

--- a/main.go
+++ b/main.go
@@ -45,8 +45,10 @@ func main() {
 	}
 
 	if *token == "" {
-		level.Error(logger).Log("err", "-token is required")
-		os.Exit(1)
+		if *token = os.Getenv("FASTLY_API_TOKEN"); *token == "" {
+			level.Error(logger).Log("err", "-token or FASTLY_API_TOKEN is required")
+			os.Exit(1)
+		}
 	}
 
 	var metrics prometheusMetrics

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var version = "dev"
 func main() {
 	fs := flag.NewFlagSet("fastly-exporter", flag.ExitOnError)
 	var (
-		token      = fs.String("token", "", "Fastly API token (required)")
+		token      = fs.String("token", "", "Fastly API token (required; also via FASTLY_API_TOKEN)")
 		serviceIDs = stringslice{}
 		addr       = fs.String("endpoint", "http://127.0.0.1:8080/metrics", "Prometheus /metrics endpoint")
 		namespace  = fs.String("namespace", "fastly", "Prometheus namespace")


### PR DESCRIPTION
New option: read environment variable `FASTLY_API_TOKEN`.

With this patch `fastly-exporter` will first check `-token` and if it's not there will try read environment variable `FASTLY_API_TOKEN`.

For security reasons we don't want to always leave token as an argument. It also simplifies setup in Kubernetes.