### PR TITLE
statically-linked binaries

### DIFF
--- a/release.fish
+++ b/release.fish
@@ -25,6 +25,6 @@ for pair in linux/amd64 darwin/amd64
 	set GOARCH (echo $pair | cut -d'/' -f2)
 	set BIN    $DISTDIR/fastly-exporter-$VERSION-$GOOS-$GOARCH
 	echo $BIN
-	env GOOS=$GOOS GOARCH=$GOARCH go build -o $BIN -ldflags="-X main.version=$VERSION" github.com/peterbourgon/fastly-exporter
+	env CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -o $BIN -ldflags="-X main.version=$VERSION" github.com/peterbourgon/fastly-exporter
 end
 


### PR DESCRIPTION
Just to keep Dockerfile in sync with binaries releases, let's keep `CGO_ENABLED=0` everywhere. There is always less problems with statically-linked binaries.

This PR fix #22 