### PR TITLE
Don't spam rt.fastly.com if -token is bad.

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -60,3 +60,22 @@ func (c *countingRealtimeClient) Do(req *http.Request) (*http.Response, error) {
 	atomic.AddUint64(&(c.served), 1)
 	return fixedResponseClient{c.code, c.response}.Do(req)
 }
+
+type userAgentCapturingClient struct {
+	userAgent atomic.Value
+}
+
+func (c *userAgentCapturingClient) Do(req *http.Request) (*http.Response, error) {
+	c.userAgent.Store(req.Header.Get("User-Agent"))
+	return fixedResponseClient{200, "{}"}.Do(req)
+}
+
+func within(d time.Duration, f func() bool) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if f() { // 🔥
+			return true
+		}
+	}
+	return false
+}

--- a/monitor.go
+++ b/monitor.go
@@ -30,6 +30,7 @@ func monitor(ctx context.Context, client httpClient, token string, serviceID str
 			if err != nil {
 				return err // fatal for sure
 			}
+			req.Header.Set("User-Agent", "Fastly-Exporter ("+version+")")
 			req.Header.Set("Fastly-Key", token)
 			req.Header.Set("Accept", "application/json")
 			resp, err := client.Do(req.WithContext(ctx))

--- a/monitor_manager_test.go
+++ b/monitor_manager_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestMonitorManager(t *testing.T) {
 	var (
-		client      = fixedResponseClient{"{}"}
+		client      = fixedResponseClient{200, "{}"}
 		token       = "irrelevant-token"
 		cache       = newNameCache()
 		metrics     = prometheusMetrics{}

--- a/service_queryer_test.go
+++ b/service_queryer_test.go
@@ -12,7 +12,7 @@ func TestServiceQueryerFixture(t *testing.T) {
 		cache   = newNameCache()
 		manager = &mockManager{}
 		queryer = newServiceQueryer(token, ids, cache, manager)
-		client  = fixedResponseClient{serviceResponseFixture}
+		client  = fixedResponseClient{200, serviceResponseFixture}
 	)
 
 	if err := queryer.refresh(client); err != nil {


### PR DESCRIPTION
It might be nicer to exit harder, but I think this is a nice compromise.