### PR TITLE
Allow filtering of exported metrics

### DIFF
--- a/pkg/filter/doc.go
+++ b/pkg/filter/doc.go
@@ -1,0 +1,2 @@
+// Package filter provides whitelist- and blacklist-based string filtering.
+package filter

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -1,0 +1,66 @@
+package filter
+
+import "regexp"
+
+// Filter collects whitelist and blacklist expressions, and allows callers to
+// check if a given string should be permitted. The zero value of a filter type
+// is useful and permits all strings.
+type Filter struct {
+	whitelist []*regexp.Regexp
+	blacklist []*regexp.Regexp
+}
+
+// Whitelist adds a regular expression to the whitelist. If the whitelist is
+// non-empty, strings must match at least one whitelist expression in order to be
+// permitted.
+func (f *Filter) Whitelist(expr string) error {
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return err
+	}
+
+	f.whitelist = append(f.whitelist, re)
+	return nil
+}
+
+// Blacklist adds a regular expression to the blacklist. If a string matches any
+// blacklist expression, it is not permitted.
+func (f *Filter) Blacklist(expr string) error {
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return err
+	}
+
+	f.blacklist = append(f.blacklist, re)
+	return nil
+}
+
+// Allow checks if the provided string is permitted, according to the current
+// set of whitelist and blacklist expressions.
+func (f *Filter) Allow(s string) (allowed bool) {
+	return f.passWhitelist(s) && f.passBlacklist(s)
+}
+
+func (f *Filter) passWhitelist(s string) bool {
+	if len(f.whitelist) <= 0 {
+		return true // default pass
+	}
+
+	for _, re := range f.whitelist {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f *Filter) passBlacklist(s string) bool {
+	for _, re := range f.blacklist {
+		if re.MatchString(s) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1,0 +1,113 @@
+package filter_test
+
+import (
+	"testing"
+
+	"github.com/peterbourgon/fastly-exporter/pkg/filter"
+)
+
+func TestFilter(t *testing.T) {
+	t.Parallel()
+
+	for _, testcase := range []struct {
+		name      string
+		whitelist []string
+		blacklist []string
+		inputs    map[string]bool
+	}{
+		{
+			name: "default allow",
+			inputs: map[string]bool{
+				"anything": true,
+				"":         true,
+			},
+		},
+		{
+			name:      "single whitelist",
+			whitelist: []string{"foo"},
+			inputs: map[string]bool{
+				"foo": true,
+				"bar": false,
+				"":    false,
+			},
+		},
+		{
+			name:      "multiple whitelist",
+			whitelist: []string{"foo", "bar"},
+			inputs: map[string]bool{
+				"foo": true,
+				"bar": true,
+				"baz": false,
+				"":    false,
+			},
+		},
+		{
+			name:      "single blacklist",
+			blacklist: []string{"foo"},
+			inputs: map[string]bool{
+				"foo": false,
+				"bar": true,
+				"":    true,
+			},
+		},
+		{
+			name:      "multiple blacklist",
+			blacklist: []string{"foo", "bar"},
+			inputs: map[string]bool{
+				"foo": false,
+				"bar": false,
+				"baz": true,
+				"":    true,
+			},
+		},
+		{
+			name:      "whitelist and blacklist",
+			whitelist: []string{"foo", "bar"},
+			blacklist: []string{"baz", "qux"},
+			inputs: map[string]bool{
+				"foo":           true,
+				"foo bar":       true,
+				"some bar blah": true,
+				"foo bar baz":   false,
+				"bar baz":       false,
+				"baz":           false,
+				"fo ba":         false,
+				"":              false,
+			},
+		},
+		{
+			name:      "actual regex",
+			whitelist: []string{"[123]xx"},
+			blacklist: []string{"bad$"},
+			inputs: map[string]bool{
+				"1xx":     true,
+				"2xx_ok":  true,
+				"3xx_bad": false,
+				"4xx":     false,
+				"5xx":     false,
+				"bad_2xx": true,
+			},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var f filter.Filter
+			for _, s := range testcase.whitelist {
+				if err := f.Whitelist(s); err != nil {
+					t.Fatalf("Whitelist(%s): %v", s, err)
+				}
+			}
+			for _, s := range testcase.blacklist {
+				if err := f.Blacklist(s); err != nil {
+					t.Fatalf("Blacklist(%s): %v", s, err)
+				}
+			}
+			for input, want := range testcase.inputs {
+				if have := f.Allow(input); want != have {
+					t.Errorf("Allow(%q): want %v, have %v", input, want, have)
+				}
+			}
+		})
+	}
+}

--- a/pkg/prom/metrics_test.go
+++ b/pkg/prom/metrics_test.go
@@ -3,31 +3,33 @@ package prom_test
 import (
 	"testing"
 
+	"github.com/peterbourgon/fastly-exporter/pkg/filter"
 	"github.com/peterbourgon/fastly-exporter/pkg/prom"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestRegistration(t *testing.T) {
 	var (
-		namespace = "namespace"
-		subsystem = "subsystem"
-		registry  = prometheus.NewRegistry()
+		namespace  = "namespace"
+		subsystem  = "subsystem"
+		nameFilter = filter.Filter{} // allow all
+		registry   = prometheus.NewRegistry()
 	)
 
 	{
-		_, err := prom.NewMetrics(namespace, subsystem, registry)
+		_, err := prom.NewMetrics(namespace, subsystem, nameFilter, registry)
 		if err != nil {
 			t.Errorf("unexpected error on first construction: %v", err)
 		}
 	}
 	{
-		_, err := prom.NewMetrics(namespace, subsystem, registry)
+		_, err := prom.NewMetrics(namespace, subsystem, nameFilter, registry)
 		if err == nil {
 			t.Error("unexpected success on second construction")
 		}
 	}
 	{
-		_, err := prom.NewMetrics("alt"+namespace, subsystem, registry)
+		_, err := prom.NewMetrics("alt"+namespace, subsystem, nameFilter, registry)
 		if err != nil {
 			t.Errorf("unexpected error on third, alt-namespace construction: %v", err)
 		}

--- a/pkg/rt/manager_test.go
+++ b/pkg/rt/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/go-cmp/cmp"
 	"github.com/peterbourgon/fastly-exporter/pkg/api"
+	"github.com/peterbourgon/fastly-exporter/pkg/filter"
 	"github.com/peterbourgon/fastly-exporter/pkg/prom"
 	"github.com/peterbourgon/fastly-exporter/pkg/rt"
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,7 +23,7 @@ func TestManager(t *testing.T) {
 		s3         = api.Service{ID: "3a3b3c", Name: "service 3", Version: 3}
 		client     = newMockRealtimeClient(`{}`)
 		token      = "irrelevant-token"
-		metrics, _ = prom.NewMetrics("namespace", "subsystem", prometheus.NewRegistry())
+		metrics, _ = prom.NewMetrics("namespace", "subsystem", filter.Filter{}, prometheus.NewRegistry())
 		logbuf     = &bytes.Buffer{}
 		logger     = log.NewLogfmtLogger(logbuf)
 		options    = []rt.SubscriberOption{rt.WithMetadataProvider(cache)}

--- a/pkg/rt/subscriber_test.go
+++ b/pkg/rt/subscriber_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/peterbourgon/fastly-exporter/pkg/api"
+	"github.com/peterbourgon/fastly-exporter/pkg/filter"
 	"github.com/peterbourgon/fastly-exporter/pkg/prom"
 	"github.com/peterbourgon/fastly-exporter/pkg/rt"
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,7 +18,8 @@ func TestSubscriberFixture(t *testing.T) {
 		namespace  = "testspace"
 		subsystem  = "testsystem"
 		registry   = prometheus.NewRegistry()
-		metrics, _ = prom.NewMetrics(namespace, subsystem, registry)
+		nameFilter = filter.Filter{}
+		metrics, _ = prom.NewMetrics(namespace, subsystem, nameFilter, registry)
 	)
 
 	var (
@@ -54,7 +56,7 @@ func TestSubscriberNoData(t *testing.T) {
 	var (
 		client      = newMockRealtimeClient(`{"Error": "No data available, please retry"}`, `{}`)
 		registry    = prometheus.NewRegistry()
-		metrics, _  = prom.NewMetrics("ns", "ss", registry)
+		metrics, _  = prom.NewMetrics("ns", "ss", filter.Filter{}, registry)
 		processed   = make(chan struct{}, 100)
 		postprocess = func() { processed <- struct{}{} }
 		options     = []rt.SubscriberOption{rt.WithPostprocess(postprocess)}
@@ -79,7 +81,7 @@ func TestUserAgent(t *testing.T) {
 	var (
 		client      = newMockRealtimeClient(`{}`)
 		userAgent   = "Some user agent string"
-		metrics, _  = prom.NewMetrics("ns", "ss", prometheus.NewRegistry())
+		metrics, _  = prom.NewMetrics("ns", "ss", filter.Filter{}, prometheus.NewRegistry())
 		processed   = make(chan struct{})
 		postprocess = func() { close(processed) }
 		options     = []rt.SubscriberOption{rt.WithUserAgent(userAgent), rt.WithPostprocess(postprocess)}
@@ -97,7 +99,7 @@ func TestUserAgent(t *testing.T) {
 func TestBadTokenNoSpam(t *testing.T) {
 	var (
 		client     = &countingRealtimeClient{code: 403, response: `{"Error": "unauthorized"}`}
-		metrics, _ = prom.NewMetrics("namespace", "subsystem", prometheus.NewRegistry())
+		metrics, _ = prom.NewMetrics("namespace", "subsystem", filter.Filter{}, prometheus.NewRegistry())
 		subscriber = rt.NewSubscriber(client, "presumably bad token", "service ID", metrics)
 	)
 	go subscriber.Run(context.Background())


### PR DESCRIPTION
This PR is a re-work of #39 that allows you to filter the Prometheus metrics that get exported. It is a **breaking change** in order to make the flags for service and metric name filtering consistent: `-{service, metric}-{whitelist, blacklist}`. The full semantics of the filtering behavior are explained in the README.

@j18e — does this solve your use case? If so, I'll push a new release shortly.