### PR TITLE
Fix config file loading

### DIFF
--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -69,7 +69,7 @@ func main() {
 		fs.BoolVar(&configFileExample, "config-file-example", false, "print example config file to stdout and exit")
 		fs.Usage = usageFor(fs)
 	}
-	ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("FASTLY_EXPORTER"), ff.WithConfigFileFlag("config-file"))
+	ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("FASTLY_EXPORTER"), ff.WithConfigFileFlag("config-file"), ff.WithConfigFileParser(ff.PlainParser))
 
 	if versionFlag {
 		fmt.Fprintf(os.Stdout, "fastly-exporter v%s\n", programVersion)


### PR DESCRIPTION
Currently `-config-file` is broken due to missing config file parser option.
```
$ ./fastly-exporter -config-file test.cfg
level=error err="-token or FASTLY_API_TOKEN is required"
```

This PR fixes it:
```
 $ ./fastly-exporter -config-file test.cfg
level=info prometheus_addr=0.0.0.0:3759 path=/metrics namespace=fastly subsystem=rt
level=info filter=metrics type="name blocklist" expr=attack
level=info filter=metrics type="name blocklist" expr=imgopto
level=info filter=metrics type="name blocklist" expr=ipv6
level=info filter=metrics type="name blocklist" expr=otfp
level=info filter=metrics type="name blocklist" expr=pci
level=info filter=metrics type="name blocklist" expr=video
level=info filter=metrics type="name blocklist" expr=waf
level=info filter=services type="explicit service IDs" count=1
level=info component=rt.fastly.com service_id=xxxxxxxxxxxxx subscriber=create
```

Would be nice if you tag the PR with `hacktoberfest-accepted` 🙏 