### PR TITLE
Use correct API field name for edge request count

### DIFF
--- a/cmd/fieldgen/api_fields.json
+++ b/cmd/fieldgen/api_fields.json
@@ -17,7 +17,7 @@
     {"field_name": "BodySize",                         "type": "uint64",             "key": "body_size"},
     {"field_name": "DeliverSubCount",                  "type": "uint64",             "key": "deliver_sub_count"},
     {"field_name": "DeliverSubTime",                   "type": "uint64",             "key": "deliver_sub_time"},
-    {"field_name": "Edge",                             "type": "uint64",             "key": "edge"},
+    {"field_name": "Edge",                             "type": "uint64",             "key": "edge_requests"},
     {"field_name": "EdgeRespBodyBytes",                "type": "uint64",             "key": "edge_resp_body_bytes"},
     {"field_name": "EdgeRespHeaderBytes",              "type": "uint64",             "key": "edge_resp_header_bytes"},
     {"field_name": "Errors",                           "type": "uint64",             "key": "errors"},

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -45,7 +45,7 @@ type Datacenter struct {
 	BodySize                        uint64            `json:"body_size"`
 	DeliverSubCount                 uint64            `json:"deliver_sub_count"`
 	DeliverSubTime                  uint64            `json:"deliver_sub_time"`
-	Edge                            uint64            `json:"edge"`
+	Edge                            uint64            `json:"edge_requests"`
 	EdgeRespBodyBytes               uint64            `json:"edge_resp_body_bytes"`
 	EdgeRespHeaderBytes             uint64            `json:"edge_resp_header_bytes"`
 	Errors                          uint64            `json:"errors"`


### PR DESCRIPTION
The edge request count is always showing as zero because it's mapped to the wrong API field name...