### PR TITLE
Avoid double counting total requests

### DIFF
--- a/cmd/fieldgen/main.go
+++ b/cmd/fieldgen/main.go
@@ -129,7 +129,6 @@ func exec() error {
 	fmt.Printf("\tfor _, d := range response.Data {\n")
 	fmt.Printf("\t\tfor datacenter, stats := range d.Datacenter {\n")
 	fmt.Printf("\t\t\tm.ServiceInfo.WithLabelValues(serviceID, serviceName, serviceVersion).Set(1)\n")
-	fmt.Printf("\t\t\tm.RequestsTotal.WithLabelValues(serviceID, serviceName, datacenter).Add(float64(stats.Requests))\n")
 	for _, m := range mappings {
 		switch m.Kind {
 		case "Counter":

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -472,7 +472,6 @@ func Process(response *APIResponse, serviceID, serviceName, serviceVersion strin
 	for _, d := range response.Data {
 		for datacenter, stats := range d.Datacenter {
 			m.ServiceInfo.WithLabelValues(serviceID, serviceName, serviceVersion).Set(1)
-			m.RequestsTotal.WithLabelValues(serviceID, serviceName, datacenter).Add(float64(stats.Requests))
 			m.AttackBlockedReqBodyBytesTotal.WithLabelValues(serviceID, serviceName, datacenter).Add(float64(stats.AttackBlockedReqBodyBytes))
 			m.AttackBlockedReqHeaderBytesTotal.WithLabelValues(serviceID, serviceName, datacenter).Add(float64(stats.AttackBlockedReqHeaderBytes))
 			m.AttackLoggedReqBodyBytesTotal.WithLabelValues(serviceID, serviceName, datacenter).Add(float64(stats.AttackLoggedReqBodyBytes))


### PR DESCRIPTION
Total requests are already counted by the defined mapping so there's no need to count them manually as well.