### PR TITLE
Add /healthz endpoint for health check

### DIFF
--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -321,6 +321,11 @@ func main() {
 	{
 		// Serve Prometheus metrics (and /debug/pprof/...) over HTTP.
 		http.Handle(promURL.Path, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		// health check endpoint
+		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(http.StatusText(http.StatusOK)))
+		})
 		server := http.Server{
 			Addr:    promURL.Host,
 			Handler: http.DefaultServeMux,


### PR DESCRIPTION
## Background

I'm not sure the design of this exporter but `GET /healthz` or any health check is useful when systems need to check availability of the exporter. So, this PR suggests introducing the health check endpoint in addition to the `/metrics` endpoint.