### PR TITLE
Refactor for Prometheus HTTP service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ docker pull mrnetops/fastly-exporter
 ### Source
 
 If you have a working Go installation, you can clone the repo and install the
-binary from any revision, including HEAD. Note that the repo doesn't support
-direct installation via e.g. `go get`.
+binary from any revision, including HEAD.
 
 ```
 git clone git@github.com:peterbourgon/fastly-exporter
 cd fastly-exporter
-env GO111MODULE=on go build ./cmd/fastly-exporter
+go build ./cmd/fastly-exporter
+./fastly-exporter -h
 ```
 
 ## Using
@@ -64,15 +64,15 @@ By default, all services available to your token will be exported. You can
 specify an explicit set of service IDs to export by using the `-service xxx`
 flag. (Service IDs are available at the top of your [Fastly dashboard][db].) You
 can also include only those services whose name matches a regex by using the
-`-service-allowlist '^Production'` flag, or skip any service whose name matches
+`-service-allowlist '^Production'` flag, or elide any service whose name matches
 a regex by using the `-service-blocklist '.*TEST.*'` flag.
 
 [db]: https://manage.fastly.com/services/all
 
 For tokens with access to a lot of services, it's possible to "shard" the
-services among different instances of the fastly-exporter by using the
-`-service-shard` flag. For example, to shard all services between 3 exporters,
-you would start each exporter as
+services among different fastly-exporter instances by using the `-service-shard`
+flag. For example, to shard all services between 3 exporters, you would start
+each exporter as
 
 ```
 fastly-exporter [common flags] -service-shard 1/3
@@ -80,7 +80,7 @@ fastly-exporter [common flags] -service-shard 2/3
 fastly-exporter [common flags] -service-shard 3/3
 ```
 
-### Filtering exported metrics
+### Filtering metrics
 
 By default, all metrics provided by the Fastly real-time stats API are exported
 as Prometheus metrics. You can export only those metrics whose name matches a
@@ -89,7 +89,7 @@ whose name matches a regex by using the `-metric-blocklist imgopto` flag.
 
 ### Filter semantics
 
-All flags that restrict services or metrics are repeatable. Repeating the same
+All flags that filter services or metrics are repeatable. Repeating the same
 flag causes its condition to be combined with OR semantics. For example,
 `-service A -service B` would include both services A and B (but not service C).
 Or, `-service-blocklist Test -service-blocklist Staging` would skip any service
@@ -98,3 +98,12 @@ whose name contained Test or Staging.
 Different flags (for the same filter target) combine with AND semantics. For
 example, `-metric-allowlist 'bytes_total$' -metric-blocklist imgopto` would only
 export metrics whose names ended in bytes_total, but didn't include imgopto.
+
+### Service discovery
+
+Available services are listed as targets on the `/sd` endpoint, in a format
+compatible with the [generic HTTP service discovery][httpsd] feature of
+Prometheus. Metrics for each service be scraped independently via
+`/metrics?target=<service ID>`.
+
+[httpsq]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/go-kit/log v0.1.0
 	github.com/google/go-cmp v0.5.5
+	github.com/gorilla/mux v1.8.0
 	github.com/json-iterator/go v1.1.11
 	github.com/oklog/run v1.0.0
 	github.com/peterbourgon/ff/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/prom/doc.go
+++ b/pkg/prom/doc.go
@@ -1,0 +1,2 @@
+// Package prom implements a custom registry which Prometheus scrapes.
+package prom

--- a/pkg/prom/registry.go
+++ b/pkg/prom/registry.go
@@ -1,0 +1,205 @@
+package prom
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/peterbourgon/fastly-exporter/pkg/filter"
+	"github.com/peterbourgon/fastly-exporter/pkg/gen"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Registry collects Prometheus metrics on a per-service basis.
+//
+// Writers (i.e. rt.Subscribers) should call MetricsFor with their specific
+// service ID, and update the returned set of Prometheus metrics. Readers (i.e.
+// Prometheus) can scrape metrics for all services via the `/metrics` endpoint,
+// or a single service via `/metrics?target=<service ID>`.
+//
+// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
+type Registry struct {
+	mtx              sync.Mutex
+	version          string
+	namespace        string
+	subsystem        string
+	metricNameFilter filter.Filter
+	byServiceID      map[string]*metricsRegistry
+
+	http.Handler
+}
+
+// NewRegistry returns a new and empty registry for Prometheus metrics.
+func NewRegistry(version, namespace, subsystem string, metricNameFilter filter.Filter) *Registry {
+	r := &Registry{
+		version:          version,
+		namespace:        namespace,
+		subsystem:        subsystem,
+		metricNameFilter: metricNameFilter,
+		byServiceID:      map[string]*metricsRegistry{},
+	}
+
+	router := mux.NewRouter()
+	router.StrictSlash(true)
+	router.Methods("GET").Path("/").HandlerFunc(r.handleIndex)
+	router.Methods("GET").Path("/sd").HandlerFunc(r.handleServiceDiscovery)
+	router.Methods("GET").Path("/metrics").HandlerFunc(r.handleMetrics)
+	r.Handler = router
+
+	return r
+}
+
+type metricsRegistry struct {
+	metrics  *gen.Metrics
+	registry *prometheus.Registry
+}
+
+// MetricsFor returns a set of Prometheus metrics for a specific service, with
+// the expectation that callers will update those metrics with data retrieved
+// from the Fastly real-time stats API.
+func (r *Registry) MetricsFor(serviceID string) *gen.Metrics {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	mr, ok := r.byServiceID[serviceID]
+	if !ok {
+		registry := prometheus.NewRegistry()
+		metrics := gen.NewMetrics(r.namespace, r.subsystem, r.metricNameFilter, registry)
+		mr = &metricsRegistry{metrics, registry}
+		r.byServiceID[serviceID] = mr // TODO(pb): at some point, expire and remove?
+	}
+
+	return mr.metrics
+}
+
+func (r *Registry) handleIndex(w http.ResponseWriter, req *http.Request) {
+	type link struct {
+		Path string `json:"path"`
+		Name string `json:"name"`
+	}
+
+	links := []link{
+		{"/sd", "Service discovery"},
+		{"/metrics", "Metrics for all services"},
+	}
+
+	for _, serviceID := range r.serviceIDs() {
+		query := url.Values{"target": []string{serviceID}}.Encode()
+		path := "/metrics?" + query
+		name := "Metrics for service " + serviceID
+		links = append(links, link{path, name})
+	}
+
+	accept := req.Header.Get("accept")
+	switch {
+	case strings.Contains(accept, "text/html"):
+		w.Header().Set("content-type", "text/html; charset=utf-8")
+		indexTemplate.Execute(w, struct {
+			Version string
+			Links   []link
+		}{
+			Version: r.version,
+			Links:   links,
+		})
+
+	case strings.Contains(accept, "application/json"):
+		w.Header().Set("content-type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "    ")
+		enc.Encode(links)
+
+	default:
+		w.Header().Set("content-type", "text/plain; charset=utf-8")
+		for _, link := range links {
+			fmt.Fprintf(w, "%s: %s\n", link.Path, link.Name)
+		}
+	}
+}
+
+func (r *Registry) handleServiceDiscovery(w http.ResponseWriter, req *http.Request) {
+	targets := r.serviceIDs()
+
+	response := []struct {
+		Targets []string `json:"targets"`
+	}{
+		{Targets: targets},
+	}
+
+	buf, err := json.MarshalIndent(response, "", "    ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("content-type", "application/json; charset=utf-8")
+	w.Write(buf)
+}
+
+func (r *Registry) handleMetrics(w http.ResponseWriter, req *http.Request) {
+	var (
+		target   = req.URL.Query().Get("target") // empty target string means all targets
+		gatherer = r.gathererFor(target)
+		handler  = promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+	)
+	handler.ServeHTTP(w, req)
+}
+
+func (r *Registry) serviceIDs() []string {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	serviceIDs := make([]string, 0, len(r.byServiceID))
+	for serviceID := range r.byServiceID {
+		serviceIDs = append(serviceIDs, serviceID)
+	}
+
+	sort.Strings(serviceIDs)
+
+	return serviceIDs
+}
+
+func (r *Registry) gathererFor(target string) prometheus.Gatherer {
+	var allow func(candidate string) bool
+	switch target {
+	case "":
+		allow = func(candidate string) bool { return true }
+	default:
+		allow = func(candidate string) bool { return candidate == target }
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	var gatherers prometheus.Gatherers
+	for serviceID, mr := range r.byServiceID {
+		if allow(serviceID) {
+			gatherers = append(gatherers, mr.registry)
+		}
+	}
+
+	return gatherers
+}
+
+var indexTemplate = template.Must(template.New("").Parse(`
+<html>
+<head>
+<title>fastly-exporter</title>
+<style>body { margin: 1em 2em; font-size: 16pt; }</style>
+</head>
+<body>
+<p>fastly-exporter{{ if .Version }} version <strong>{{ .Version }}</strong>{{ end }}</p>
+<ul>
+{{ range .Links -}}
+<li><a href="{{ .Path }}">{{ .Name }}</a></li>
+{{ end -}}
+</ul>
+</body>
+</html>
+`))

--- a/pkg/prom/registry_test.go
+++ b/pkg/prom/registry_test.go
@@ -1,0 +1,142 @@
+package prom_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/fastly-exporter/pkg/filter"
+	"github.com/peterbourgon/fastly-exporter/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestRegistryEndpoints(t *testing.T) {
+	t.Parallel()
+
+	var (
+		version          = "dev"
+		namespace        = "fastly"
+		subsystem        = "rt"
+		metricNameFilter = filter.Filter{}
+		registry         = prom.NewRegistry(version, namespace, subsystem, metricNameFilter)
+	)
+
+	registry.MetricsFor("AAA").RequestsTotal.With(prometheus.Labels{
+		"service_id": "AAA", "service_name": "Service One", "datacenter": "NYC",
+	}).Add(1)
+
+	registry.MetricsFor("BBB").RequestsTotal.With(prometheus.Labels{
+		"service_id": "BBB", "service_name": "Service Two", "datacenter": "NYC",
+	}).Add(2)
+
+	server := httptest.NewServer(registry)
+	defer server.Close()
+
+	get := func(path string) (body string) {
+		t.Helper()
+
+		resp, err := http.Get(server.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if want, have := http.StatusOK, resp.StatusCode; want != have {
+			t.Fatalf("code: want %d, have %d", want, have)
+		}
+
+		buf, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return string(buf)
+	}
+
+	expect := func(b bool, msg string) {
+		t.Helper()
+		if !b {
+			t.Error(msg)
+		}
+	}
+
+	checkMetrics := func(body string, want, dont []string) {
+		wantmap := make(map[string]struct{}, len(want))
+		for _, s := range want {
+			wantmap[s] = struct{}{}
+		}
+
+		dontmap := make(map[string]struct{}, len(dont))
+		for _, s := range dont {
+			dontmap[s] = struct{}{}
+		}
+
+		lines := strings.Split(body, "\n")
+		for _, line := range lines {
+			for s := range wantmap {
+				if strings.HasPrefix(line, s) {
+					delete(wantmap, s)
+				}
+			}
+			for s := range dontmap {
+				if strings.HasPrefix(line, s) {
+					t.Errorf("extra: %s", line)
+				}
+			}
+		}
+		for s := range wantmap {
+			t.Errorf("missing: %s", s)
+		}
+	}
+
+	t.Run("index", func(t *testing.T) {
+		body := get("/")
+		expect(strings.Contains(body, "AAA"), "AAA missing")
+		expect(strings.Contains(body, "BBB"), "BBB missing")
+	})
+
+	t.Run("sd", func(t *testing.T) {
+		body := get("/sd")
+		expect(strings.Contains(body, "AAA"), "AAA missing")
+		expect(strings.Contains(body, "BBB"), "BBB missing")
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		body := get("/metrics")
+		want, dont := []string{
+			`fastly_rt_requests_total{datacenter="NYC",service_id="AAA",service_name="Service One"} 1`,
+			`fastly_rt_requests_total{datacenter="NYC",service_id="BBB",service_name="Service Two"} 2`,
+		}, []string{}
+		checkMetrics(body, want, dont)
+	})
+
+	t.Run("metrics?target=AAA", func(t *testing.T) {
+		body := get("/metrics?target=AAA")
+		want, dont := []string{
+			`fastly_rt_requests_total{datacenter="NYC",service_id="AAA",service_name="Service One"} 1`,
+		}, []string{
+			`fastly_rt_requests_total{datacenter="NYC",service_id="BBB",service_name="Service Two"} 2`,
+		}
+		checkMetrics(body, want, dont)
+	})
+
+	t.Run("metrics?target=BBB", func(t *testing.T) {
+		body := get("/metrics?target=BBB")
+		want, dont := []string{
+			`fastly_rt_requests_total{datacenter="NYC",service_id="BBB",service_name="Service Two"} 2`,
+		}, []string{
+			`fastly_rt_requests_total{datacenter="NYC",service_id="AAA",service_name="Service One"} 1`,
+		}
+		checkMetrics(body, want, dont)
+	})
+
+	t.Run("metrics?target=CCC", func(t *testing.T) {
+		body := get("/metrics?target=CCC")
+		want, dont := []string{}, []string{
+			`fastly_rt_requests_total{datacenter="NYC",service_id="AAA",service_name="Service One"} 1`,
+			`fastly_rt_requests_total{datacenter="NYC",service_id="BBB",service_name="Service Two"} 2`,
+		}
+		checkMetrics(body, want, dont)
+	})
+}

--- a/pkg/rt/manager_test.go
+++ b/pkg/rt/manager_test.go
@@ -10,24 +10,23 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/peterbourgon/fastly-exporter/pkg/api"
 	"github.com/peterbourgon/fastly-exporter/pkg/filter"
-	"github.com/peterbourgon/fastly-exporter/pkg/gen"
+	"github.com/peterbourgon/fastly-exporter/pkg/prom"
 	"github.com/peterbourgon/fastly-exporter/pkg/rt"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestManager(t *testing.T) {
 	var (
-		cache      = &mockCache{}
-		s1         = api.Service{ID: "101010", Name: "service 1", Version: 1}
-		s2         = api.Service{ID: "2f2f2f", Name: "service 2", Version: 2}
-		s3         = api.Service{ID: "3a3b3c", Name: "service 3", Version: 3}
-		client     = newMockRealtimeClient(`{}`)
-		token      = "irrelevant-token"
-		metrics, _ = gen.NewMetrics("namespace", "subsystem", filter.Filter{}, prometheus.NewRegistry())
-		logbuf     = &bytes.Buffer{}
-		logger     = log.NewLogfmtLogger(logbuf)
-		options    = []rt.SubscriberOption{rt.WithMetadataProvider(cache)}
-		manager    = rt.NewManager(cache, client, token, metrics, options, level.NewFilter(logger, level.AllowInfo()))
+		cache    = &mockCache{}
+		s1       = api.Service{ID: "101010", Name: "service 1", Version: 1}
+		s2       = api.Service{ID: "2f2f2f", Name: "service 2", Version: 2}
+		s3       = api.Service{ID: "3a3b3c", Name: "service 3", Version: 3}
+		client   = newMockRealtimeClient(`{}`)
+		token    = "irrelevant-token"
+		registry = prom.NewRegistry("v0.0.0-DEV", "namespace", "subsystem", filter.Filter{})
+		logbuf   = &bytes.Buffer{}
+		logger   = log.NewLogfmtLogger(logbuf)
+		options  = []rt.SubscriberOption{rt.WithMetadataProvider(cache)}
+		manager  = rt.NewManager(cache, client, token, registry, options, level.NewFilter(logger, level.AllowInfo()))
 	)
 
 	assertStringSliceEqual(t, []string{}, manager.Active())

--- a/pkg/rt/subscriber_test.go
+++ b/pkg/rt/subscriber_test.go
@@ -19,7 +19,7 @@ func TestSubscriberFixture(t *testing.T) {
 		subsystem  = "testsystem"
 		registry   = prometheus.NewRegistry()
 		nameFilter = filter.Filter{}
-		metrics, _ = gen.NewMetrics(namespace, subsystem, nameFilter, registry)
+		metrics    = gen.NewMetrics(namespace, subsystem, nameFilter, registry)
 	)
 
 	var (
@@ -57,7 +57,7 @@ func TestSubscriberNoData(t *testing.T) {
 	var (
 		client      = newMockRealtimeClient(`{"Error": "No data available, please retry"}`, `{}`)
 		registry    = prometheus.NewRegistry()
-		metrics, _  = gen.NewMetrics("ns", "ss", filter.Filter{}, registry)
+		metrics     = gen.NewMetrics("ns", "ss", filter.Filter{}, registry)
 		processed   = make(chan struct{}, 100)
 		postprocess = func() { processed <- struct{}{} }
 		options     = []rt.SubscriberOption{rt.WithPostprocess(postprocess)}
@@ -83,7 +83,7 @@ func TestUserAgent(t *testing.T) {
 	var (
 		client      = newMockRealtimeClient(`{}`)
 		userAgent   = "Some user agent string"
-		metrics, _  = gen.NewMetrics("ns", "ss", filter.Filter{}, prometheus.NewRegistry())
+		metrics     = gen.NewMetrics("ns", "ss", filter.Filter{}, prometheus.NewRegistry())
 		processed   = make(chan struct{})
 		postprocess = func() { close(processed) }
 		options     = []rt.SubscriberOption{rt.WithUserAgent(userAgent), rt.WithPostprocess(postprocess)}
@@ -101,7 +101,7 @@ func TestUserAgent(t *testing.T) {
 func TestBadTokenNoSpam(t *testing.T) {
 	var (
 		client     = &countingRealtimeClient{code: 403, response: `{"Error": "unauthorized"}`}
-		metrics, _ = gen.NewMetrics("namespace", "subsystem", filter.Filter{}, prometheus.NewRegistry())
+		metrics    = gen.NewMetrics("namespace", "subsystem", filter.Filter{}, prometheus.NewRegistry())
 		subscriber = rt.NewSubscriber(client, "presumably bad token", "service ID", metrics)
 	)
 	go subscriber.Run(context.Background())

--- a/release.fish
+++ b/release.fish
@@ -1,18 +1,14 @@
 #!/usr/bin/env fish
 
 function version_prompt
-	echo "Semantic version: "
+	echo "Semantic version (e.g. '0.11.9'): "
 end
 
 read --prompt version_prompt VERSION
 
-if test (echo $VERSION | grep '^v')
-	echo Use the raw semantic version, without a v prefix
-	exit
-end
-
-set REV (git rev-parse --short HEAD)
-echo Tagging $REV as v$VERSION
+set VERSION  (echo $VERSION | sed -e 's/^v//')
+set REVISION (git rev-parse --short HEAD)
+echo Tagging $REVISION as v$VERSION
 git tag --annotate v$VERSION -m "Release v$VERSION"
 echo Be sure to: git push --tags
 echo


### PR DESCRIPTION
This PR will be a refactor to address #66 and part of #70.

- `-endpoint <url>` removed, `-listen [<host>]:<port>` added
- `/metrics` still yields metrics for all services
- `/metrics?target={serviceID}` now does a single service
- `/sd` should be compatible with [Prometheus generic HTTP SD](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config)
- Add index page
