### PR TITLE
Allow custom User Agent for all API invocations

### DIFF
--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -55,7 +55,7 @@ func main() {
 		fs.StringVar(&namespace, "namespace", "fastly", "Prometheus namespace")
 		fs.StringVar(&subsystem, "subsystem", "rt", "Prometheus subsystem")
 		fs.StringVar(&serviceShard, "service-shard", "", "if set, only include services whose hashed IDs modulo m equal n-1 (format 'n/m')")
-		fs.StringVar(&userAgent, "api-user-agent", `Fastly-Exporter (`+programVersion+`)`, "if set, override the reporting user-agent HTTP header")
+		fs.StringVar(&userAgent, "api-user-agent", "", "if set, override the reporting user-agent HTTP header")
 		fs.Var(&serviceIDs, "service", "if set, only include this service ID (repeatable)")
 		fs.Var(&serviceAllowlist, "service-allowlist", "if set, only include services whose names match this regex (repeatable)")
 		fs.Var(&serviceBlocklist, "service-blocklist", "if set, don't include services whose names match this regex (repeatable)")
@@ -79,6 +79,10 @@ func main() {
 	); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
+	}
+
+	if userAgent == "" {
+		userAgent = `Fastly-Exporter (` + programVersion + `)`
 	}
 
 	if versionFlag {

--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -297,7 +297,6 @@ func main() {
 			subscriberOptions = []rt.SubscriberOption{
 				rt.WithLogger(rtLogger),
 				rt.WithMetadataProvider(serviceCache),
-				rt.WithUserAgent(`Fastly-Exporter (` + programVersion + `)`),
 			}
 		)
 		rtClient.Transport = api.NewCustomUserAgent(rtClient.Transport, userAgent)

--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -33,6 +33,7 @@ func main() {
 		namespace         string
 		subsystem         string
 		serviceShard      string
+		userAgent         string
 		serviceIDs        stringslice
 		serviceAllowlist  stringslice
 		serviceBlocklist  stringslice
@@ -54,6 +55,7 @@ func main() {
 		fs.StringVar(&namespace, "namespace", "fastly", "Prometheus namespace")
 		fs.StringVar(&subsystem, "subsystem", "rt", "Prometheus subsystem")
 		fs.StringVar(&serviceShard, "service-shard", "", "if set, only include services whose hashed IDs modulo m equal n-1 (format 'n/m')")
+		fs.StringVar(&userAgent, "api-user-agent", `Fastly-Exporter (`+programVersion+`)`, "if set, override the reporting user-agent HTTP header")
 		fs.Var(&serviceIDs, "service", "if set, only include this service ID (repeatable)")
 		fs.Var(&serviceAllowlist, "service-allowlist", "if set, only include services whose names match this regex (repeatable)")
 		fs.Var(&serviceBlocklist, "service-blocklist", "if set, don't include services whose names match this regex (repeatable)")
@@ -228,6 +230,8 @@ func main() {
 		}
 	}
 
+	apiClient.Transport = api.NewCustomUserAgent(apiClient.Transport, userAgent)
+
 	var serviceCache *api.ServiceCache
 	{
 		serviceCacheOptions := []api.ServiceCacheOption{
@@ -296,6 +300,7 @@ func main() {
 				rt.WithUserAgent(`Fastly-Exporter (` + programVersion + `)`),
 			}
 		)
+		rtClient.Transport = api.NewCustomUserAgent(rtClient.Transport, userAgent)
 		manager = rt.NewManager(serviceCache, rtClient, token, registry, subscriberOptions, rtLogger)
 		manager.Refresh() // populate initial subscribers, based on the initial cache refresh
 	}

--- a/pkg/api/user_agent.go
+++ b/pkg/api/user_agent.go
@@ -9,15 +9,22 @@ type CustomUserAgent struct {
 	rt              http.RoundTripper
 }
 
+// DefaultUserAgent passed to HTTPClient when the User-Agent
+// HTTP header is not set.
+const DefaultUserAgent = "Fastly-Exporter (unknown version)"
+
 // RoundTrip satisfies the http.RoundTripper interface for CustomUserAgent
 func (cua *CustomUserAgent) RoundTrip(req *http.Request) (*http.Response, error) {
+	if cua.agentIdentifier == "" {
+		cua.agentIdentifier = DefaultUserAgent
+	}
 	req.Header.Set("User-Agent", cua.agentIdentifier)
 	return cua.rt.RoundTrip(req)
 }
 
 // NewCustomUserAgent the provided http.Roundtriper will set
 // the User-Agent header for each request.
-func NewCustomUserAgent(rt http.RoundTripper, agentIdentifier string) *CustomUserAgent {
+func NewCustomUserAgent(rt http.RoundTripper, agentIdentifier string) http.RoundTripper {
 	return &CustomUserAgent{
 		agentIdentifier,
 		rt,

--- a/pkg/api/user_agent.go
+++ b/pkg/api/user_agent.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+)
+
+type CustomUserAgent struct {
+	agentIdentifier string
+	rt              http.RoundTripper
+}
+
+// RoundTrip satisfies the http.RoundTripper interface for CustomUserAgent
+func (cua *CustomUserAgent) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", cua.agentIdentifier)
+	return cua.rt.RoundTrip(req)
+}
+
+// NewCustomUserAgent the provided http.Roundtriper will set
+// the User-Agent header for each request.
+func NewCustomUserAgent(rt http.RoundTripper, agentIdentifier string) *CustomUserAgent {
+	return &CustomUserAgent{
+		agentIdentifier,
+		rt,
+	}
+}

--- a/pkg/api/user_agent_test.go
+++ b/pkg/api/user_agent_test.go
@@ -1,0 +1,69 @@
+package api_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/peterbourgon/fastly-exporter/pkg/api"
+)
+
+func TestCustomUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		ua   string
+		want string
+	}{
+		{
+			name: "no UA provided",
+			ua:   "",
+			want: "",
+		},
+		{
+			name: "UA provided",
+			ua:   "someclient/v1.2.0",
+			want: "someclient/v1.2.0",
+		},
+	}
+
+	for _, testcase := range tt {
+		t.Run(testcase.name, func(t *testing.T) {
+			mockres := io.NopCloser(bytes.NewBuffer([]byte(`{}`)))
+			transporter := mockTransport(mockres)
+			uaTransporter := api.NewCustomUserAgent(transporter, testcase.ua)
+			c := http.Client{
+				Transport: uaTransporter,
+			}
+
+			res, err := c.Get("/")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer res.Body.Close()
+
+			if want, have := testcase.want, res.Request.Header.Get("User-Agent"); !cmp.Equal(want, have) {
+				t.Fatal(cmp.Diff(want, have))
+			}
+
+		})
+	}
+}
+
+type uaTransport struct {
+	body io.ReadCloser
+}
+
+func (t *uaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var resp http.Response
+	resp.Body = t.body
+	resp.Request = req
+	return &resp, nil
+}
+
+func mockTransport(body io.ReadCloser) http.RoundTripper {
+	return &uaTransport{body: body}
+}

--- a/pkg/rt/common_test.go
+++ b/pkg/rt/common_test.go
@@ -109,9 +109,8 @@ func (c *mockCache) Metadata(id string) (name string, version int, found bool) {
 //
 
 type mockRealtimeClient struct {
-	responses     []string
-	next          chan struct{}
-	lastUserAgent string
+	responses []string
+	next      chan struct{}
 }
 
 func newMockRealtimeClient(responses ...string) *mockRealtimeClient {
@@ -136,8 +135,6 @@ func (c *mockRealtimeClient) Do(req *http.Request) (*http.Response, error) {
 	} else {
 		response, c.responses = c.responses[0], c.responses[1:]
 	}
-
-	c.lastUserAgent = req.Header.Get("User-Agent")
 
 	return fixedResponseClient{200, response}.Do(req)
 }

--- a/pkg/rt/subscriber_test.go
+++ b/pkg/rt/subscriber_test.go
@@ -79,25 +79,6 @@ func TestSubscriberNoData(t *testing.T) {
 	assertMetricOutput(t, want, have)
 }
 
-func TestUserAgent(t *testing.T) {
-	var (
-		client      = newMockRealtimeClient(`{}`)
-		userAgent   = "Some user agent string"
-		metrics     = gen.NewMetrics("ns", "ss", filter.Filter{}, prometheus.NewRegistry())
-		processed   = make(chan struct{})
-		postprocess = func() { close(processed) }
-		options     = []rt.SubscriberOption{rt.WithUserAgent(userAgent), rt.WithPostprocess(postprocess)}
-		subscriber  = rt.NewSubscriber(client, "token", "service_id", metrics, options...)
-	)
-	go subscriber.Run(context.Background())
-
-	<-processed
-
-	if want, have := userAgent, client.lastUserAgent; want != have {
-		t.Errorf("User-Agent: want %q, have %q", want, have)
-	}
-}
-
 func TestBadTokenNoSpam(t *testing.T) {
 	var (
 		client     = &countingRealtimeClient{code: 403, response: `{"Error": "unauthorized"}`}


### PR DESCRIPTION
### TL;DR

This PR implements the custom user agent request initiated by @phamann from https://github.com/peterbourgon/fastly-exporter/issues/90

### Why?

`http.RoundTripper` was selected to drive this solution because it was very obvious, configurable and is similar to the approach taken with `rt.WithUserAgent` injecting the user agent at runtime. 

@peterbourgon  suggested baking the user agent at build time. This was not explored as it is unclear if this meant adding to the linker Flag invocation in the Makefile or something else. Guidance is appreciated and I am happy to explore this solution or any mods to this PR (reference: https://github.com/peterbourgon/fastly-exporter/issues/90#issuecomment-1008150330).

👋🏿 @peterbourgon hope you are well and thanks for the review :) 

### Note:

n/a
