### PR TITLE
Fix pagination link extraction

### DIFF
--- a/pkg/api/link.go
+++ b/pkg/api/link.go
@@ -34,38 +34,40 @@ func uriFromLinks(links []string, k, v string) (string, bool) {
 
 func uriFromLink(link, k, v string) (string, bool) {
 	var rawuri string
-	for _, param := range strings.Split(link, ";") {
-		param = strings.TrimSpace(param)
-		if param == "" {
-			continue
-		}
+	for _, link := range strings.Split(link, ",") {
+		for _, param := range strings.Split(link, ";") {
+			param = strings.TrimSpace(param)
+			if param == "" {
+				continue
+			}
 
-		if rawuri == "" && param[0] == '<' && param[len(param)-1] == '>' {
-			rawuri = strings.Trim(param, "<>")
-			continue
-		}
+			if param[0] == '<' && param[len(param)-1] == '>' {
+				rawuri = strings.Trim(param, "<>")
+				continue
+			}
 
-		keyval := strings.SplitN(param, "=", 2)
-		if len(keyval) != 2 {
-			continue
-		}
+			keyval := strings.SplitN(param, "=", 2)
+			if len(keyval) != 2 {
+				continue
+			}
 
-		key := strings.TrimSpace(keyval[0])
-		if !strings.EqualFold(key, k) {
-			continue
-		}
+			key := strings.TrimSpace(keyval[0])
+			if !strings.EqualFold(key, k) {
+				continue
+			}
 
-		var val string
-		val = keyval[1]
-		val = strings.TrimSpace(val)
-		val = strings.Trim(val, `"`)
-		val = strings.TrimSpace(val)
-		if !strings.EqualFold(val, v) {
-			continue
-		}
+			var val string
+			val = keyval[1]
+			val = strings.TrimSpace(val)
+			val = strings.Trim(val, `"`)
+			val = strings.TrimSpace(val)
+			if !strings.EqualFold(val, v) {
+				continue
+			}
 
-		if rawuri != "" {
-			return rawuri, true
+			if rawuri != "" {
+				return rawuri, true
+			}
 		}
 	}
 	return "", false

--- a/pkg/api/link_test.go
+++ b/pkg/api/link_test.go
@@ -73,6 +73,11 @@ func TestGetNextLink(t *testing.T) {
 			want:  `https://api.github.com/user/58276/repos?page=2`,
 		},
 		{
+			name:  `linkheader 4`,
+			links: []string{"<https://api.github.com/user/58276/repos?page=9>; rel=\"last\", <https://api.github.com/user/58276/repos?page=2>; rel=\"next\""},
+			want:  `https://api.github.com/user/58276/repos?page=2`,
+		},
+		{
 			name:  `link 1`,
 			links: []string{`<https://example.com/?page=2>; rel="next"; title="foo"`},
 			want:  `https://example.com/?page=2`,


### PR DESCRIPTION
Fixes: #93 

Diff is mainly whitespace change, best best viewed with [`?w=1`](https://github.com/peterbourgon/fastly-exporter/pull/94/files?w=1)