### PR TITLE
Increase the service cache request page size from 100 to 1000

### DIFF
--- a/pkg/api/service_cache.go
+++ b/pkg/api/service_cache.go
@@ -15,6 +15,10 @@ import (
 	"github.com/peterbourgon/fastly-exporter/pkg/filter"
 )
 
+// maxServicePageSize is the maximum amount of results that can be requested
+// from the api.fastly.com/service endpoint.
+const maxServicePageSize = 1000
+
 // Service metadata associated with a single service.
 // Also serves as a DTO for api.fastly.com/service.
 type Service struct {
@@ -92,7 +96,7 @@ func (c *ServiceCache) Refresh(ctx context.Context) error {
 	begin := time.Now()
 
 	var (
-		uri     = "https://api.fastly.com/service?page=1&per_page=100"
+		uri     = fmt.Sprintf("https://api.fastly.com/service?page=1&per_page=%d", maxServicePageSize)
 		total   = 0
 		nextgen = map[string]Service{}
 	)


### PR DESCRIPTION
### TL;DR
We have recently increased the maximum result page size of the `/service` endpoint from 100 to 1000. Therefore, this PR bumps the size the exporter uses to fetch the serivce list to `1000` and should hopefully reduce requests to the Fastly API by 10x.