### PR TITLE
trigger workflows on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 jobs:
   test:
     strategy:


### PR DESCRIPTION
[PRs from forks](https://github.com/fastly/fastly-exporter/pull/102) are not triggering CI. I think it may be because we don't have `on: [push, pull_request]` in the workflow file. 