### PR TITLE
Add documentation how to install fastly-exporter via Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ docker pull ghcr.io/fastly/fastly-exporter:latest
 Note that version `latest` will track RCs, alphas, etc. -- always use an
 explicit version in production.
 
+### Helm chart
+
+[Helm](https://helm.sh) must be installed to use the [prometheus-community/fastly-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prom-label-proxy) chart.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+```
+
+```console
+helm upgrade --install fastly-exporter prometheus-fastly-exporter --namespace monitoring --set token="fastly_api_token"
+```
+
 ### Source
 
 If you have a working Go installation, you can clone the repo and install the
@@ -60,21 +75,6 @@ This will collect real-time stats for all Fastly services visible to your token,
 and make them available as Prometheus metrics on [127.0.0.1:8080/metrics][local].
 
 [local]: http://127.0.0.1:8080/metrics
-
-### Helm chart
-
-[Helm](https://helm.sh) must be installed to use the [prometheus-community/fastly-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prom-label-proxy) chart.
-Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
-
-Once Helm is set up properly, add the repo as follows:
-
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-```
-
-```console
-helm upgrade --install fastly-exporter prometheus-fastly-exporter --namespace monitoring --set token="fastly_api_token"
-```
 
 ### Filtering services
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ explicit version in production.
 
 ### Helm chart
 
-[Helm](https://helm.sh) must be installed to use the [prometheus-community/fastly-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prom-label-proxy) chart.
+[Helm](https://helm.sh) must be installed to use the [prometheus-community/fastly-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-fastly-exporter) chart.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
 Once Helm is set up properly, add the repo as follows:

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
 Once Helm is set up properly, add the repo as follows:
 
-```console
+```sh
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
 
-```console
+And install:
+
+```sh
 helm upgrade --install fastly-exporter prometheus-fastly-exporter --namespace monitoring --set token="fastly_api_token"
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ and make them available as Prometheus metrics on [127.0.0.1:8080/metrics][local]
 
 [local]: http://127.0.0.1:8080/metrics
 
+### Helm chart
+
+[Helm](https://helm.sh) must be installed to use the [prometheus-community/fastly-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prom-label-proxy) chart.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+```
+
+```console
+helm upgrade --install fastly-exporter prometheus-fastly-exporter --namespace monitoring --set token="fastly_api_token"
+```
+
 ### Filtering services
 
 By default, all services available to your token will be exported. You can


### PR DESCRIPTION
Added documentation on how to install the exporter via helm chart.
https://github.com/prometheus-community/helm-charts/pull/2278

Signed-off-by: Denis Arslanbekov <arslanbekov@gmail.com>