### PR TITLE
Add product entitlement check for Origin Inspector before enabling the subscriber for origins.

### DIFF
--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -39,6 +39,7 @@ func main() {
 		metricAllowlist     stringslice
 		metricBlocklist     stringslice
 		datacenterRefresh   time.Duration
+		productRefresh      time.Duration
 		serviceRefresh      time.Duration
 		apiTimeout          time.Duration
 		rtTimeout           time.Duration
@@ -60,6 +61,7 @@ func main() {
 		fs.Var(&metricAllowlist, "metric-allowlist", "if set, only export metrics whose names match this regex (repeatable)")
 		fs.Var(&metricBlocklist, "metric-blocklist", "if set, don't export metrics whose names match this regex (repeatable)")
 		fs.DurationVar(&datacenterRefresh, "datacenter-refresh", 10*time.Minute, "how often to poll api.fastly.com for updated datacenter metadata (10m–1h)")
+		fs.DurationVar(&productRefresh, "product-refresh", 10*time.Minute, "how often to poll api.fastly.com for updated product metadata (10m–1h)")
 		fs.DurationVar(&serviceRefresh, "service-refresh", 1*time.Minute, "how often to poll api.fastly.com for updated service metadata (15s–10m)")
 		fs.DurationVar(&serviceRefresh, "api-refresh", 1*time.Minute, "DEPRECATED -- use service-refresh instead")
 		fs.DurationVar(&apiTimeout, "api-timeout", 15*time.Second, "HTTP client timeout for api.fastly.com requests (5–60s)")
@@ -126,6 +128,14 @@ func main() {
 		if datacenterRefresh > 1*time.Hour {
 			level.Warn(logger).Log("msg", "-datacenter-refresh cannot be longer than 1h; setting it to 1h")
 			datacenterRefresh = 1 * time.Hour
+		}
+		if productRefresh < 10*time.Minute {
+			level.Warn(logger).Log("msg", "-product-refresh cannot be shorter than 10m; setting it to 10m")
+			productRefresh = 10 * time.Minute
+		}
+		if productRefresh > 1*time.Hour {
+			level.Warn(logger).Log("msg", "-product-refresh cannot be longer than 1h; setting it to 1h")
+			productRefresh = 1 * time.Hour
 		}
 		if serviceRefresh < 15*time.Second {
 			level.Warn(logger).Log("msg", "-service-refresh cannot be shorter than 15s; setting it to 15s")
@@ -282,7 +292,7 @@ func main() {
 		})
 		g.Go(func() error {
 			if err := productCache.Refresh(context.Background()); err != nil {
-				level.Warn(logger).Log("during", "initial fetch of products", "err", err, "msg", "products API unavailable")
+				level.Warn(logger).Log("during", "initial fetch of products", "err", err, "msg", "products API unavailable, will retry")
 			}
 			return nil
 		})
@@ -333,6 +343,29 @@ func main() {
 				case <-ticker.C:
 					if err := datacenterCache.Refresh(ctx); err != nil {
 						level.Warn(apiLogger).Log("during", "datacenter refresh", "err", err, "msg", "the datacenter info metrics may be stale")
+					}
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}, func(error) {
+			ticker.Stop()
+			cancel()
+		})
+	}
+	{
+		// Every productRefresh, ask the api.ProductCache to refresh
+		// data from the product entitlement endpoint.
+		var (
+			ctx, cancel = context.WithCancel(context.Background())
+			ticker      = time.NewTicker(productRefresh)
+		)
+		g.Add(func() error {
+			for {
+				select {
+				case <-ticker.C:
+					if err := productCache.Refresh(ctx); err != nil {
+						level.Warn(apiLogger).Log("during", "product refresh", "err", err, "msg", "the product entitlement data may be stale")
 					}
 				case <-ctx.Done():
 					return ctx.Err()

--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the fastly-exporter.
 package main
 
 import (

--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -281,7 +281,7 @@ func main() {
 			return nil
 		})
 		g.Go(func() error {
-			if err := productCache.Fetch(context.Background()); err != nil {
+			if err := productCache.Refresh(context.Background()); err != nil {
 				level.Warn(logger).Log("during", "initial fetch of products", "err", err, "msg", "products API unavailable")
 			}
 			return nil

--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -315,7 +315,7 @@ func main() {
 				rt.WithMetadataProvider(serviceCache),
 			}
 		)
-		manager = rt.NewManager(serviceCache, rtClient, token, registry, subscriberOptions, productCache.Products(), rtLogger)
+		manager = rt.NewManager(serviceCache, rtClient, token, registry, subscriberOptions, productCache, rtLogger)
 		manager.Refresh() // populate initial subscribers, based on the initial cache refresh
 	}
 

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -54,3 +54,33 @@ func (c paginatedResponseClient) Do(req *http.Request) (*http.Response, error) {
 	}).ServeHTTP(rec, req)
 	return rec.Result(), nil
 }
+
+//
+//
+//
+
+type sequentialResponseClient struct {
+	responses []string
+}
+
+func newSequentialResponseClient(responses ...string) *sequentialResponseClient {
+	return &sequentialResponseClient{
+		responses: responses,
+	}
+}
+
+func (c *sequentialResponseClient) Do(req *http.Request) (*http.Response, error) {
+	var response string
+	if len(c.responses) <= 1 {
+		response = c.responses[0]
+	} else {
+		response, c.responses = c.responses[0], c.responses[1:]
+	}
+
+	rec := httptest.NewRecorder()
+	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, response)
+	}).ServeHTTP(rec, req)
+	return rec.Result(), nil
+}

--- a/pkg/api/link_test.go
+++ b/pkg/api/link_test.go
@@ -30,9 +30,9 @@ func TestGetNextLink(t *testing.T) {
 		},
 
 		{
-			name: `RFC 5988 1`,
+			name:  `RFC 5988 1`,
 			links: []string{` <http://example.com/TheBook/chapter2>; rel="previous";			title="previous chapter"`},
-			want: ``,
+			want:  ``,
 		},
 		{
 			name:  `RFC 5988 2`,

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -12,13 +12,16 @@ import (
 )
 
 const (
-	Default         = "default"
+	// Default is the standard real-time stats available to all services
+	Default = "default"
+	// OriginInspector is the product name used to determine access to Origin Inspector via the entitlement API
 	OriginInspector = "origin_inspector"
 )
 
+// Products is the slice of available products supported by real-time stats.
 var Products = []string{Default, OriginInspector}
 
-// Product models the response from the Fastly Product Entitlement API
+// Product models the response from the Fastly Product Entitlement API.
 type Product struct {
 	HasAccess bool `json:"has_access"`
 	Meta      struct {
@@ -57,7 +60,6 @@ func (p *ProductCache) Refresh(ctx context.Context) error {
 		uri := fmt.Sprintf("https://api.fastly.com/entitled-products/%s", product)
 
 		req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
-
 		if err != nil {
 			return fmt.Errorf("error constructing API product request: %w", err)
 		}
@@ -65,7 +67,6 @@ func (p *ProductCache) Refresh(ctx context.Context) error {
 		req.Header.Set("Fastly-Key", p.token)
 		req.Header.Set("Accept", "application/json")
 		resp, err := p.client.Do(req)
-
 		if err != nil {
 			return fmt.Errorf("error executing API product request: %w", err)
 		}
@@ -102,7 +103,6 @@ func (p *ProductCache) HasAccess(product string) bool {
 	defer p.mtx.Unlock()
 	if v, ok := p.products[product]; ok {
 		return v
-	} else {
-		return true
 	}
+	return true
 }

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// ProductAccess models the response from the Fastly Product Entitlement API
+type ProductAccess struct {
+	Product   `json:"product"`
+	HasAccess bool `json:"has_access"`
+}
+
+// Product models product metadata return from the Fastly Product Entitlement API
+type Product struct {
+	Name string `json:"id"`
+}
+
+// ProductCache fetches product information from the Fastly Product Entitlement API
+// and stores results in a local cache.
+type ProductCache struct {
+	client HTTPClient
+	token  string
+	logger log.Logger
+
+	products map[string]bool
+}
+
+// NewProductCache returns an empty cache of Product information. Use the Fetch method
+// to populate with data.
+func NewProductCache(client HTTPClient, token string, logger log.Logger) *ProductCache {
+	return &ProductCache{
+		client:   client,
+		token:    token,
+		logger:   logger,
+		products: make(map[string]bool),
+	}
+}
+
+// Fetch requests data from the Fastly API and stores data in the cache.
+func (p *ProductCache) Fetch(ctx context.Context) error {
+	var products = []string{"origin_inspector", "domain_inspector"}
+
+	for _, product := range products {
+		uri := fmt.Sprintf("https://api.fastly.com/entitled-products/flonk/%s", product)
+
+		req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
+
+		if err != nil {
+			return fmt.Errorf("error constructing API product request: %w", err)
+		}
+
+		req.Header.Set("Fastly-Key", p.token)
+		req.Header.Set("Accept", "application/json")
+		resp, err := p.client.Do(req)
+
+		if err != nil {
+			return fmt.Errorf("error executing API product request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return NewError(resp)
+		}
+
+		var response ProductAccess
+
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			return fmt.Errorf("error decoding API product response: %w", err)
+		}
+
+		level.Debug(p.logger).Log("product", response.Name, "hasAccess", response.HasAccess)
+
+		p.products[response.Name] = response.HasAccess
+	}
+	return nil
+}
+
+// Products returns the list of products
+func (p *ProductCache) Products() map[string]bool {
+	return p.products
+}

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -42,8 +42,8 @@ func NewProductCache(client HTTPClient, token string, logger log.Logger) *Produc
 	}
 }
 
-// Fetch requests data from the Fastly API and stores data in the cache.
-func (p *ProductCache) Fetch(ctx context.Context) error {
+// Refresh requests data from the Fastly API and stores data in the cache.
+func (p *ProductCache) Refresh(ctx context.Context) error {
 	var products = []string{"origin_inspector", "domain_inspector"}
 
 	for _, product := range products {

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -28,7 +28,7 @@ type ProductCache struct {
 	token  string
 	logger log.Logger
 
-	products map[string]bool
+	products map[string]struct{}
 }
 
 // NewProductCache returns an empty cache of Product information. Use the Fetch method
@@ -38,7 +38,7 @@ func NewProductCache(client HTTPClient, token string, logger log.Logger) *Produc
 		client:   client,
 		token:    token,
 		logger:   logger,
-		products: make(map[string]bool),
+		products: make(map[string]struct{}),
 	}
 }
 
@@ -76,12 +76,16 @@ func (p *ProductCache) Refresh(ctx context.Context) error {
 
 		level.Debug(p.logger).Log("product", response.Name, "hasAccess", response.HasAccess)
 
-		p.products[response.Name] = response.HasAccess
+		if response.HasAccess {
+			p.products[response.Name] = struct{}{}
+		}
+
 	}
 	return nil
 }
 
 // Products returns the list of products
-func (p *ProductCache) Products() map[string]bool {
-	return p.products
+func (p *ProductCache) HasAccess(product string) bool {
+	_, ok := p.products[product]
+	return ok
 }

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -37,7 +37,7 @@ type ProductCache struct {
 	products map[string]struct{}
 }
 
-// NewProductCache returns an empty cache of Product information. Use the Fetch method
+// NewProductCache returns an empty cache of Product information. Use the Refresh method
 // to populate with data.
 func NewProductCache(client HTTPClient, token string, logger log.Logger) *ProductCache {
 	return &ProductCache{
@@ -93,8 +93,8 @@ func (p *ProductCache) Refresh(ctx context.Context) error {
 	return nil
 }
 
-// HassAcces takes a product as a string and returns a boolean
-// based on the reponse from the Product API.
+// HasAccess takes a product as a string and returns a boolean
+// based on the response from the Product API.
 func (p *ProductCache) HasAccess(product string) bool {
 	if product == Default {
 		return true

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -103,6 +103,6 @@ func (p *ProductCache) HasAccess(product string) bool {
 	if v, ok := p.products[product]; ok {
 		return v
 	} else {
-		return false
+		return true
 	}
 }

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -1,0 +1,87 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/fastly/fastly-exporter/pkg/api"
+	"github.com/go-kit/log"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestProductCache(t *testing.T) {
+	t.Parallel()
+
+	for _, testcase := range []struct {
+		name      string
+		client    api.HTTPClient
+		wantProds map[string]bool
+		wantErr   error
+	}{
+		{
+			name:    "success",
+			client:  newSequentialResponseClient(productsResponseOne, productsResponseTwo),
+			wantErr: nil,
+			wantProds: map[string]bool{
+				"origin_inspector": true,
+				"domain_inspector": false,
+			},
+		},
+		{
+			name:      "error",
+			client:    fixedResponseClient{code: http.StatusUnauthorized},
+			wantErr:   &api.Error{Code: http.StatusUnauthorized},
+			wantProds: map[string]bool{},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			var (
+				ctx    = context.Background()
+				client = testcase.client
+				cache  = api.NewProductCache(client, "irrelevant token", log.NewNopLogger())
+			)
+
+			//err
+			if want, have := testcase.wantErr, cache.Fetch(ctx); !cmp.Equal(want, have) {
+				t.Fatal(cmp.Diff(want, have))
+			}
+
+			if want, have := testcase.wantProds, cache.Products(); !cmp.Equal(want, have) {
+				t.Fatal(cmp.Diff(want, have))
+			}
+		})
+	}
+}
+
+const productsResponseOne = `
+{
+  "product": {
+    "id": "origin_inspector",
+    "object": "product"
+  },
+  "has_access": true,
+  "access_level": "Origin_Inspector",
+  "has_permission_to_enable": false,
+  "has_permission_to_disable": true,
+  "_links": {
+    "self": ""
+  }
+}
+`
+
+const productsResponseTwo = `
+{
+  "product": {
+    "id": "domain_inspector",
+    "object": "product"
+  },
+  "has_access": false,
+  "access_level": "Domain_Inspector",
+  "has_permission_to_enable": false,
+  "has_permission_to_disable": true,
+  "_links": {
+    "self": ""
+  }
+}
+`

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -47,8 +47,10 @@ func TestProductCache(t *testing.T) {
 				t.Fatal(cmp.Diff(want, have))
 			}
 
-			if want, have := testcase.wantProds, cache.Products(); !cmp.Equal(want, have) {
-				t.Fatal(cmp.Diff(want, have))
+			for k, v := range testcase.wantProds {
+				if v != cache.HasAccess(k) {
+					t.Fatalf("expected %v, got %v for %v", v, cache.HasAccess(k), k)
+				}
 			}
 		})
 	}

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -25,7 +25,6 @@ func TestProductCache(t *testing.T) {
 			wantErr: nil,
 			wantProds: map[string]bool{
 				"origin_inspector": true,
-				"domain_inspector": false,
 			},
 		},
 		{
@@ -42,7 +41,7 @@ func TestProductCache(t *testing.T) {
 				cache  = api.NewProductCache(client, "irrelevant token", log.NewNopLogger())
 			)
 
-			//err
+			// err
 			if want, have := testcase.wantErr, cache.Refresh(ctx); !cmp.Equal(want, have) {
 				t.Fatal(cmp.Diff(want, have))
 			}

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -43,7 +43,7 @@ func TestProductCache(t *testing.T) {
 			)
 
 			//err
-			if want, have := testcase.wantErr, cache.Fetch(ctx); !cmp.Equal(want, have) {
+			if want, have := testcase.wantErr, cache.Refresh(ctx); !cmp.Equal(want, have) {
 				t.Fatal(cmp.Diff(want, have))
 			}
 

--- a/pkg/rt/common_test.go
+++ b/pkg/rt/common_test.go
@@ -107,6 +107,37 @@ func (c *mockCache) Metadata(id string) (name string, version int, found bool) {
 //
 //
 
+type mockProductCache struct {
+	mtx      sync.RWMutex
+	products map[string]bool
+}
+
+func newMockProductCache() *mockProductCache {
+	return &mockProductCache{
+		products: make(map[string]bool),
+	}
+}
+
+func (c *mockProductCache) HasAccess(product string) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if v, ok := c.products[product]; ok {
+		return v
+	}
+	return true
+}
+
+func (c *mockProductCache) update(product string, hasAccess bool) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.products[product] = hasAccess
+}
+
+//
+//
+//
+
 type mockRealtimeClient struct {
 	responses     []string
 	next          chan struct{}

--- a/pkg/rt/manager.go
+++ b/pkg/rt/manager.go
@@ -17,6 +17,11 @@ type ServiceIdentifier interface {
 	ServiceIDs() []string
 }
 
+// ProductCache represents the api.ProductCache behavior.
+type ProductCache interface {
+	HasAccess(string) bool
+}
+
 // MetricsProvider is a consumer contract for a subscriber manager. It models
 // the method of the prom.Registry which yields a set of Prometheus metrics for
 // a specific service ID.
@@ -38,7 +43,7 @@ type Manager struct {
 	token             string
 	metrics           MetricsProvider
 	subscriberOptions []SubscriberOption
-	productCache      *api.ProductCache
+	productCache      ProductCache
 	logger            log.Logger
 
 	mtx     sync.RWMutex
@@ -49,7 +54,7 @@ type Manager struct {
 // regular schedule to keep the set of managed subscribers up-to-date. The HTTP
 // client, token, metrics, and subscriber options parameters are passed thru to
 // constructed subscribers.
-func NewManager(ids ServiceIdentifier, client HTTPClient, token string, metrics MetricsProvider, subscriberOptions []SubscriberOption, productCache *api.ProductCache, logger log.Logger) *Manager {
+func NewManager(ids ServiceIdentifier, client HTTPClient, token string, metrics MetricsProvider, subscriberOptions []SubscriberOption, productCache ProductCache, logger log.Logger) *Manager {
 	return &Manager{
 		ids:               ids,
 		client:            client,

--- a/pkg/rt/manager.go
+++ b/pkg/rt/manager.go
@@ -96,13 +96,12 @@ func (m *Manager) Refresh() {
 			}
 		}
 
-		for key := range m.managed {
+		for key, irq := range m.managed {
 			if key.product != product {
 				continue
 			}
 
 			level.Info(m.logger).Log("service_id", key.serviceID, "type", key.product, "subscriber", "stop")
-			irq := m.managed[key]
 			irq.cancel()
 			err := <-irq.done
 			delete(m.managed, key)
@@ -143,9 +142,8 @@ func (m *Manager) StopAll() {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	for key := range m.managed {
+	for key, irq := range m.managed {
 		level.Info(m.logger).Log("service_id", key.serviceID, "type", key.product, "subscriber", "stop")
-		irq := m.managed[key]
 		irq.cancel()
 		for i := 0; i < cap(irq.done); i++ {
 			err := <-irq.done

--- a/pkg/rt/manager_test.go
+++ b/pkg/rt/manager_test.go
@@ -63,16 +63,16 @@ func TestManager(t *testing.T) {
 	assertStringSliceEqual(t, []string{}, manager.Active())
 
 	if want, have := []string{
-		`level=info service_id=101010 subscriber=create`,
-		`level=info service_id=2f2f2f subscriber=create`,
-		`level=info service_id=3a3b3c subscriber=create`,
-		`level=info service_id=101010 subscriber=stop`,
-		`level=info service_id=3a3b3c subscriber=stop`,
-		`level=info service_id=2f2f2f subscriber=stop`,
-		`level=info service_id=2f2f2f subscriber=create`,
-		`level=info service_id=3a3b3c subscriber=create`,
-		`level=info service_id=2f2f2f subscriber=stop`,
-		`level=info service_id=3a3b3c subscriber=stop`,
+		`level=info service_id=101010 type=default subscriber=create`,
+		`level=info service_id=2f2f2f type=default subscriber=create`,
+		`level=info service_id=3a3b3c type=default subscriber=create`,
+		`level=info service_id=101010 type=default subscriber=stop`,
+		`level=info service_id=3a3b3c type=default subscriber=stop`,
+		`level=info service_id=2f2f2f type=default subscriber=stop`,
+		`level=info service_id=2f2f2f type=default subscriber=create`,
+		`level=info service_id=3a3b3c type=default subscriber=create`,
+		`level=info service_id=2f2f2f type=default subscriber=stop`,
+		`level=info service_id=3a3b3c type=default subscriber=stop`,
 	}, strings.Split(strings.TrimSpace(logbuf.String()), "\n"); !cmp.Equal(want, have) {
 		t.Error(cmp.Diff(want, have))
 	}

--- a/pkg/rt/manager_test.go
+++ b/pkg/rt/manager_test.go
@@ -26,7 +26,8 @@ func TestManager(t *testing.T) {
 		logbuf   = &bytes.Buffer{}
 		logger   = log.NewLogfmtLogger(logbuf)
 		options  = []rt.SubscriberOption{rt.WithMetadataProvider(cache)}
-		manager  = rt.NewManager(cache, client, token, registry, options, level.NewFilter(logger, level.AllowInfo()))
+		products = map[string]bool{}
+		manager  = rt.NewManager(cache, client, token, registry, options, products, level.NewFilter(logger, level.AllowInfo()))
 	)
 
 	assertStringSliceEqual(t, []string{}, manager.Active())

--- a/pkg/rt/manager_test.go
+++ b/pkg/rt/manager_test.go
@@ -26,7 +26,7 @@ func TestManager(t *testing.T) {
 		logbuf   = &bytes.Buffer{}
 		logger   = log.NewLogfmtLogger(logbuf)
 		options  = []rt.SubscriberOption{rt.WithMetadataProvider(cache)}
-		products = map[string]bool{}
+		products = &api.ProductCache{}
 		manager  = rt.NewManager(cache, client, token, registry, options, products, level.NewFilter(logger, level.AllowInfo()))
 	)
 


### PR DESCRIPTION
If origin inspector has not been enabled all requests for real time origin metrics will no data. This PR checks for the product before calling `subscriber.RunOrigins`.

It will not update once the exporter is running so when origin inspector has been purchased or enabled at the customer level, the exporter will need to be restarted.