### PR TITLE
Reduce load on service endpoint by excluding versions from the response

### DIFF
--- a/pkg/api/link.go
+++ b/pkg/api/link.go
@@ -16,11 +16,17 @@ func GetNextLink(resp *http.Response) (*url.URL, error) {
 		return nil, fmt.Errorf(`rel="next": no match`)
 	}
 
-	if resp.Request != nil && resp.Request.URL != nil {
-		return resp.Request.URL.Parse(rawuri)
+	unescapedURI, err := url.QueryUnescape(rawuri)
+	// if QueryUnescape() returns an error, just use the rawuri
+	if err != nil {
+		unescapedURI = rawuri
 	}
 
-	return url.Parse(rawuri)
+	if resp.Request != nil && resp.Request.URL != nil {
+		return resp.Request.URL.Parse(unescapedURI)
+	}
+
+	return url.Parse(unescapedURI)
 }
 
 func uriFromLinks(links []string, k, v string) (string, bool) {

--- a/pkg/api/link_test.go
+++ b/pkg/api/link_test.go
@@ -135,6 +135,12 @@ func TestGetNextLink(t *testing.T) {
 			links: []string{`<abc/def?page=2>; rel="next"; datetime="Mon, 03 Sep 2007 14:52:48 GMT"`},
 			want:  `https://zombo.com/retained/path/including_last_element/abc/def?page=2`,
 		},
+		{
+			name:  `rel 5 with []`,
+			req:   `https://zombo.com/with_brackets?filter[foo]=bar`,
+			links: []string{`</with_brackets?filter%5Bfoo%5D=bar&page=2>; rel="next"; datetime="Mon, 03 Sep 2007 14:52:48 GMT"`},
+			want:  `https://zombo.com/with_brackets?filter[foo]=bar&page=2`,
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			var (

--- a/pkg/api/service_cache.go
+++ b/pkg/api/service_cache.go
@@ -96,7 +96,7 @@ func (c *ServiceCache) Refresh(ctx context.Context) error {
 	begin := time.Now()
 
 	var (
-		uri     = fmt.Sprintf("https://api.fastly.com/service?page=1&per_page=%d", maxServicePageSize)
+		uri     = fmt.Sprintf("https://api.fastly.com/service?page=1&per_page=%d&filter%%5Binclude_versions%%5D=false", maxServicePageSize)
 		total   = 0
 		nextgen = map[string]Service{}
 	)

--- a/pkg/rt/manager_test.go
+++ b/pkg/rt/manager_test.go
@@ -74,7 +74,7 @@ func TestManager(t *testing.T) {
 	manager.StopAll() // stop s1
 	assertStringSliceEqual(t, []string{}, sortedServiceIDs(manager))
 
-	if want, have := []string{
+	want := []string{
 		`level=info service_id=101010 type=default subscriber=create`,
 		`level=info service_id=2f2f2f type=default subscriber=create`,
 		`level=info service_id=3a3b3c type=default subscriber=create`,
@@ -89,7 +89,12 @@ func TestManager(t *testing.T) {
 		`level=info service_id=101010 type=origin_inspector subscriber=create`,
 		`level=info service_id=101010 type=default subscriber=stop`,
 		`level=info service_id=101010 type=origin_inspector subscriber=stop`,
-	}, strings.Split(strings.TrimSpace(logbuf.String()), "\n"); !cmp.Equal(want, have) {
+	}
+	have := strings.Split(strings.TrimSpace(logbuf.String()), "\n")
+	sort.Strings(want)
+	sort.Strings(have)
+
+	if !cmp.Equal(want, have) {
 		t.Error(cmp.Diff(want, have))
 	}
 }


### PR DESCRIPTION
add query param `filter[include_versions]=false` to `/services` call. This ensures that the API doesn not return all versions for each service and will improve performance.

This has one small side effect -- services without an active version will no longer report the last active version as their version number bit will instead report `version=0`

before:
```
level=info component=api.fastly.com service=found service_id=SERVICE_ID name=bloggy version=2
```

after:
```
level=info component=api.fastly.com service=found service_id=SERVICE_ID name=bloggy version=0
```

This affects the `fastly_rt_service_info` gauge which has a `version` label. Since inactive services won't have any results from realtime stats I think this is an acceptable change.
