### PR TITLE
Update product cache to use /entitlements endpoint

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -54,33 +54,3 @@ func (c paginatedResponseClient) Do(req *http.Request) (*http.Response, error) {
 	}).ServeHTTP(rec, req)
 	return rec.Result(), nil
 }
-
-//
-//
-//
-
-type sequentialResponseClient struct {
-	responses []string
-}
-
-func newSequentialResponseClient(responses ...string) *sequentialResponseClient {
-	return &sequentialResponseClient{
-		responses: responses,
-	}
-}
-
-func (c *sequentialResponseClient) Do(req *http.Request) (*http.Response, error) {
-	var response string
-	if len(c.responses) <= 1 {
-		response = c.responses[0]
-	} else {
-		response, c.responses = c.responses[0], c.responses[1:]
-	}
-
-	rec := httptest.NewRecorder()
-	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, response)
-	}).ServeHTTP(rec, req)
-	return rec.Result(), nil
-}

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -88,13 +88,7 @@ func (p *ProductCache) Refresh(ctx context.Context) error {
 	activeProducts := make(map[string]interface{})
 
 	for _, customer := range response.Customers {
-		if customer.Contracts == nil {
-			continue
-		}
 		for _, contract := range customer.Contracts {
-			if contract.Items == nil {
-				continue
-			}
 			for _, item := range contract.Items {
 				if item.ProductID == nil {
 					continue

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -21,11 +21,17 @@ func TestProductCache(t *testing.T) {
 	}{
 		{
 			name:    "success",
-			client:  newSequentialResponseClient(productsResponse),
+			client:  fixedResponseClient{response: productsResponse, code: http.StatusOK},
 			wantErr: nil,
 			wantProds: map[string]bool{
 				"origin_inspector": true,
 			},
+		},
+		{
+			name:      "noCustomerSuccess",
+			client:    fixedResponseClient{response: noCustomerResponse, code: http.StatusOK},
+			wantErr:   nil,
+			wantProds: map[string]bool{},
 		},
 		{
 			name:      "error",
@@ -76,7 +82,16 @@ const productsResponse = `
           ]
         }
       ]
+    },
+    {
+      "other key": {}
     }
   ]
+}
+`
+
+const noCustomerResponse = `
+{
+  "metadata": {}
 }
 `

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -21,7 +21,7 @@ func TestProductCache(t *testing.T) {
 	}{
 		{
 			name:    "success",
-			client:  newSequentialResponseClient(productsResponseOne, productsResponseTwo),
+			client:  newSequentialResponseClient(productsResponse),
 			wantErr: nil,
 			wantProds: map[string]bool{
 				"origin_inspector": true,
@@ -55,34 +55,28 @@ func TestProductCache(t *testing.T) {
 	}
 }
 
-const productsResponseOne = `
+// only products that the customer is entitled to are returned from the /entitlements endpoint
+const productsResponse = `
 {
-  "product": {
-    "id": "origin_inspector",
-    "object": "product"
-  },
-  "has_access": true,
-  "access_level": "Origin_Inspector",
-  "has_permission_to_enable": false,
-  "has_permission_to_disable": true,
-  "_links": {
-    "self": ""
-  }
-}
-`
-
-const productsResponseTwo = `
-{
-  "product": {
-    "id": "domain_inspector",
-    "object": "product"
-  },
-  "has_access": false,
-  "access_level": "Domain_Inspector",
-  "has_permission_to_enable": false,
-  "has_permission_to_disable": true,
-  "_links": {
-    "self": ""
-  }
+  "customers": [
+    {
+      "contracts": [
+        {
+          "items": [
+            {
+              "product_id": "origin_inspector"
+            },
+            {
+              "other_key": "other"
+            }
+          ]
+        },
+        {
+          "other_key_2": [
+          ]
+        }
+      ]
+    }
+  ]
 }
 `


### PR DESCRIPTION
Switch to use `/entitlements` endpoint rather than `/entitled-products`.

**Do not merge or create a release from this draft. This is for testing purposes only at the moment.**