### PR TITLE
Add build info metrics

### DIFF
--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -330,6 +330,13 @@ func main() {
 		}
 	}
 
+	bg, err := prom.BuildInfoGatherer(namespace, deprecatedSubsystem)
+	if err != nil {
+		level.Error(apiLogger).Log("during", "create build info gatherer", "err", err)
+	} else {
+		defaultGatherers = append(defaultGatherers, bg)
+	}
+
 	var registry *prom.Registry
 	{
 		registry = prom.NewRegistry(programVersion, namespace, deprecatedSubsystem, metricNameFilter, defaultGatherers)

--- a/pkg/prom/build_info.go
+++ b/pkg/prom/build_info.go
@@ -1,0 +1,19 @@
+package prom
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors/version"
+)
+
+// BuildInfoGatherer returns a Prometheus Gatherer that includes build information.
+func BuildInfoGatherer(namespace, subsystem string) (prometheus.Gatherer, error) {
+	registry := prometheus.NewRegistry()
+	buildinfoCollector := version.NewCollector(fmt.Sprintf("%s_%s", namespace, subsystem))
+	err := registry.Register(buildinfoCollector)
+	if err != nil {
+		return nil, fmt.Errorf("registering build info collector: %w", err)
+	}
+	return registry, nil
+}


### PR DESCRIPTION
Adds the prometheus version collector: https://github.com/prometheus/client_golang/blob/v1.22.0/prometheus/collectors/version/version.go

sample metrics output:

```
 # HELP fastly_rt_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which fastly_rt was built, and the goos and goarch for the build.
 # TYPE fastly_rt_build_info gauge
 fastly_rt_build_info{branch="",goarch="arm64",goos="darwin",goversion="go1.24.1",revision="unknown",tags="unknown",version=""} 1
```

fixes #173
