### PR TITLE
Add an arm64 build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: CI
+
 on: [push, pull_request]
+
 jobs:
   test:
     strategy:
@@ -36,22 +38,44 @@ jobs:
   assets:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+        target:
+          - { name: linux-amd64,  runner: ubuntu-latest, goos: linux,   goarch: amd64 }
+          - { name: windows-amd64,runner: windows-latest,goos: windows, goarch: amd64 }
+          - { name: linux-arm64,  runner: ubuntu-latest, goos: linux,   goarch: arm64 }
+    runs-on: ${{ matrix.target.runner }}
     needs: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: 1.x
-      - run: echo "APP_VERSION=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" >> $GITHUB_ENV
+
+      - name: Set App Version
+        run: echo "APP_VERSION=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" >> $GITHUB_ENV
         shell: bash
-      - run: echo "ASSET_NAME=fastly-exporter-${{ env.APP_VERSION }}.$(go env GOOS)-$(go env GOARCH).tar.gz" >> $GITHUB_ENV
+
+      - name: Set Go Environment for Target
+        env:
+          TARGET_GOOS: ${{ matrix.target.goos }}
+          TARGET_GOARCH: ${{ matrix.target.goarch }}
+        run: |
+          echo "GOOS=${TARGET_GOOS}" >> $GITHUB_ENV
+          echo "GOARCH=${TARGET_GOARCH}" >> $GITHUB_ENV
         shell: bash
-      - run: echo "ASSET_PATH=dist/v${{ env.APP_VERSION }}/${{ env.ASSET_NAME }}" >> $GITHUB_ENV
+
+      - name: Set Asset Name
+        run: echo "ASSET_NAME=fastly-exporter-${{ env.APP_VERSION }}.$(go env GOOS)-$(go env GOARCH).tar.gz" >> $GITHUB_ENV
         shell: bash
-      - run: make dist
-      - uses: actions/upload-release-asset@v1
+
+      - name: Set Asset Path
+        run: echo "ASSET_PATH=dist/v${{ env.APP_VERSION }}/${{ env.ASSET_NAME }}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Build distributable
+        run: make dist # This will use GOOS/GOARCH from the environment
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -59,7 +83,7 @@ jobs:
           asset_path: ${{ env.ASSET_PATH }}
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/gzip
-
+          
   docker:
     runs-on: ubuntu-latest
     needs: release


### PR DESCRIPTION
In addition to adding an `arm64` build, this tidies up the `ci.yaml` file a bit:

- Closes #200.
- Makes the `target` matrix more explicit
- Assigns names to some of the unnamed job steps, for quicker / easier debugging in the build output
- Adds some readability spacing