### PR TITLE
Add linux/arm64 for the Docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,14 +66,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+      
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Docker auth
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v3
+      
+      - name: Add Docker metadata
+        uses: docker/metadata-action@v3
         id: meta
         with:
           images: ghcr.io/fastly/fastly-exporter
@@ -83,8 +92,11 @@ jobs:
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{version}}
-      - uses: docker/build-push-action@v2
+      
+      - name: Docker build and push
+        uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM golang:latest AS builder
+
 RUN groupadd -r fastly-exporter
 RUN useradd -r -g fastly-exporter fastly-exporter
+
 WORKDIR /app
+
 COPY go.mod .
 COPY go.sum .
+
 RUN go mod download
+
 ADD .git .git
 ADD cmd cmd
 ADD pkg pkg
+
 RUN env CGO_ENABLED=0 go build \
 	-a \
 	-ldflags="-X main.programVersion=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" \
@@ -15,9 +21,17 @@ RUN env CGO_ENABLED=0 go build \
 	./cmd/fastly-exporter
 
 FROM scratch
+
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /fastly-exporter /fastly-exporter
+
 USER fastly-exporter
+
 EXPOSE 8080
+
 ENTRYPOINT ["/fastly-exporter", "-listen=0.0.0.0:8080"]
+
+LABEL org.opencontainers.image.source="https://github.com/fastly/fastly-exporter/"
+LABEL org.opencontainers.image.description="Fastly Prometheus Exporter container image"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,11 @@ ${DIST_DIR}:
 ${DIST_ZIP}: ${DIST_BIN}
 	tar -C ${DIST_DIR} -c -z -f ${DIST_ZIP} ${DIST_BIN_FILE}
 
-${DOCKER_ZIP}: ${SOURCE} Dockerfile
+.PHONY: docker-build
+docker-build: ${SOURCE} Dockerfile
 	${DOCKER} build --tag=${DOCKER_TAG} .
+
+${DOCKER_ZIP}: docker-build
 	${DOCKER} save --output=$@ ${DOCKER_TAG}
 
 ${STATICCHECK}:


### PR DESCRIPTION
This PR:

1. Adds the `docker/setup-qemu-action` step, to enable multi-arch builds
2. Adds `linux/arm64` to the "Build and Push" step
3. Adds [labels](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images) to the Dockerfile
4. Gives each step a name, to make future debugging easier