### PR TITLE
CI: add a Docker dry-run job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,11 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: 1.x
       - run: make lint
@@ -45,8 +48,11 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     needs: release
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Check out repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: 1.x
 
@@ -91,7 +97,7 @@ jobs:
       packages: write
     
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up QEMU
@@ -135,7 +141,7 @@ jobs:
       packages: write
       
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up QEMU

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,8 +83,48 @@ jobs:
           asset_path: ${{ env.ASSET_PATH }}
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/gzip
-          
-  docker:
+  
+  docker-dry-run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Docker auth
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Add Docker metadata
+        uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: ghcr.io/fastly/fastly-exporter
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=v{{major}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{version}}
+      
+      - name: Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false # This indicates a dry run
+          tags: ${{ steps.meta.outputs.tags }}
+  
+  docker-release:
     runs-on: ubuntu-latest
     needs: release
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
       - name: Docker auth
         uses: docker/login-action@v1
         with:
@@ -137,6 +140,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
       - name: Docker auth
         uses: docker/login-action@v1


### PR DESCRIPTION
There may be a better way to do this, but it seemed worth trying.

- Adds a new `docker-dry-run` job with `push: false` set, which means it will do the `docker build` but not push it to the GH package registry.