### PR TITLE
update build tags to actually work with prometheus/common/version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set App Version
+        run: echo "APP_VERSION=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set Branch
+        run: echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+        shell: bash
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -132,7 +140,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false # This indicates a dry run
           tags: ${{ steps.meta.outputs.tags }}
-  
+          build-args: |
+            VERSION=${{ env.APP_VERISON }}
+            BRANCH=${{ env.BRANCH }}
+
   docker-release:
     runs-on: ubuntu-latest
     needs: release
@@ -143,6 +154,14 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set App Version
+        run: echo "APP_VERSION=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set Branch
+        run: echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -176,3 +195,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ env.APP_VERISON }}
+            BRANCH=${{ env.BRANCH }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:latest AS builder
+ARG VERSION=0.0.0-unknown
+ARG BRANCH=main
 
 RUN groupadd -r fastly-exporter
 RUN useradd -r -g fastly-exporter fastly-exporter
@@ -16,7 +18,7 @@ ADD pkg pkg
 
 RUN env CGO_ENABLED=0 go build \
 	-a \
-	-ldflags="-X main.programVersion=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" \
+	-ldflags="-X main.programVersion=$VERSION -X github.com/prometheus/common/version.Version=$VERSION -X github.com/prometheus/common/version.Branch=$BRANCH" \
 	-o /fastly-exporter \
 	./cmd/fastly-exporter
 


### PR DESCRIPTION
We added buildInfo metrics in #210  but didn't properly set the `ldflags` to populate the metrics.
