### PR TITLE
Make Fastly API and RT base URLs configurable via envvars

### DIFF
--- a/cmd/fastly-exporter/main.go
+++ b/cmd/fastly-exporter/main.go
@@ -80,7 +80,8 @@ func main() {
 		fs.BoolVar(&configFileExample, "config-file-example", false, "print example config file to stdout and exit")
 		fs.Usage = usageFor(fs)
 	}
-	if err := ff.Parse(fs, os.Args[1:],
+	if err := ff.Parse(
+		fs, os.Args[1:],
 		ff.WithEnvVarPrefix("FASTLY_EXPORTER"),
 		ff.WithConfigFileFlag("config-file"),
 		ff.WithConfigFileParser(ff.PlainParser),
@@ -111,6 +112,10 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	baseDomain := os.Getenv("FASTLY_BASE_URL")
+	apiBaseURL := api.BaseURL(baseDomain)
+	rtBaseURL := api.RTBaseURL(baseDomain)
 
 	switch deprecatedSubsystem {
 	case "rt":
@@ -291,30 +296,30 @@ func main() {
 			serviceCacheOptions = append(serviceCacheOptions, api.WithShard(shardN, shardM))
 		}
 
-		serviceCache = api.NewServiceCache(apiClient, token, serviceCacheOptions...)
+		serviceCache = api.NewServiceCache(apiClient, token, apiBaseURL, serviceCacheOptions...)
 	}
 
 	var certificateCache *api.CertificateCache
 	{
 		enabled := certificateRefresh != 0 && !metricNameFilter.Blocked(prometheus.BuildFQName(namespace, deprecatedSubsystem, "cert_expiry_timestamp_seconds"))
-		certificateCache = api.NewCertificateCache(apiClient, token, enabled, logger)
+		certificateCache = api.NewCertificateCache(apiClient, token, apiBaseURL, enabled, logger)
 	}
 	var datacenterCache *api.DatacenterCache
 	{
 		enabled := !metricNameFilter.Blocked(prometheus.BuildFQName(namespace, deprecatedSubsystem, "datacenter_info"))
-		datacenterCache = api.NewDatacenterCache(apiClient, token, enabled)
+		datacenterCache = api.NewDatacenterCache(apiClient, token, apiBaseURL, enabled)
 	}
 
 	var productCache *api.ProductCache
 	{
-		productCache = api.NewProductCache(apiClient, token, apiLogger)
+		productCache = api.NewProductCache(apiClient, token, apiBaseURL, apiLogger)
 	}
 
 	// Dictionary info cache (digest, item_count, last_updated) -> Prom metrics
 	var dictionaryCache *api.DictionaryInfoCache
 	{
 		enabled := !metricNameFilter.Blocked(prometheus.BuildFQName(namespace, deprecatedSubsystem, "dictionary_item_count"))
-		dictionaryCache = api.NewDictionaryInfoCache(apiClient, token, apiLogger, serviceCache, enabled)
+		dictionaryCache = api.NewDictionaryInfoCache(apiClient, token, apiBaseURL, apiLogger, serviceCache, enabled)
 	}
 
 	{
@@ -392,7 +397,7 @@ func main() {
 	}
 
 	if !metricNameFilter.Blocked(prometheus.BuildFQName(namespace, deprecatedSubsystem, "token_expiration")) {
-		tokenRecorder := api.NewTokenRecorder(apiClient, token)
+		tokenRecorder := api.NewTokenRecorder(apiClient, token, apiBaseURL)
 		tg, err := tokenRecorder.Gatherer(namespace, deprecatedSubsystem)
 		if err != nil {
 			level.Error(apiLogger).Log("during", "create token gatherer", "err", err)
@@ -426,6 +431,7 @@ func main() {
 				rt.WithLogger(rtLogger),
 				rt.WithMetadataProvider(serviceCache),
 				rt.WithAggregateOnly(aggregateOnly),
+				rt.WithBaseURL(rtBaseURL),
 			}
 		)
 		manager = rt.NewManager(serviceCache, rtClient, token, registry, subscriberOptions, productCache, rtLogger)

--- a/pkg/api/certificate_cache.go
+++ b/pkg/api/certificate_cache.go
@@ -53,6 +53,7 @@ type Attributes struct {
 type CertificateCache struct {
 	client  HTTPClient
 	token   string
+	baseURL string
 	enabled bool
 	logger  log.Logger
 
@@ -62,10 +63,14 @@ type CertificateCache struct {
 
 // NewCertificateCache returns an empty cache of certificates metadata. Use the
 // Refresh method to update the cache.
-func NewCertificateCache(client HTTPClient, token string, enabled bool, logger log.Logger) *CertificateCache {
+func NewCertificateCache(client HTTPClient, token, baseURL string, enabled bool, logger log.Logger) *CertificateCache {
+	if baseURL == "" {
+		baseURL = BaseURL("")
+	}
 	return &CertificateCache{
 		client:  client,
 		token:   token,
+		baseURL: baseURL,
 		enabled: enabled,
 		logger:  logger,
 	}
@@ -79,7 +84,7 @@ func (c *CertificateCache) Refresh(ctx context.Context) error {
 	begin := time.Now()
 
 	var (
-		uri       = fmt.Sprintf("https://api.fastly.com/tls/certificates?page%%5Bnumber%%5D=1&page%%5Bsize%%5D=%d&sort=created_at", maxCertificatesPageSize)
+		uri       = fmt.Sprintf("%s/tls/certificates?page%%5Bnumber%%5D=1&page%%5Bsize%%5D=%d&sort=created_at", c.baseURL, maxCertificatesPageSize)
 		nextCerts = []Certificate{}
 		total     = 0
 	)

--- a/pkg/api/certificate_cache_test.go
+++ b/pkg/api/certificate_cache_test.go
@@ -67,7 +67,7 @@ func TestCertificateCache(t *testing.T) {
 			var (
 				ctx    = context.Background()
 				client = testcase.client
-				cache  = api.NewCertificateCache(client, "irrelevant token", true, log.NewNopLogger())
+				cache  = api.NewCertificateCache(client, "irrelevant token", "", true, log.NewNopLogger())
 			)
 
 			if want, have := testcase.wantErr, cache.Refresh(ctx); !cmp.Equal(want, have) {

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -6,6 +6,26 @@ import (
 	"strings"
 )
 
+// DefaultBaseDomain is the default Fastly base domain.
+// API and RT URLs are derived as https://api.{domain} and https://rt.{domain}.
+const DefaultBaseDomain = "fastly.com"
+
+// BaseURL returns the full API base URL for a given base domain.
+func BaseURL(baseDomain string) string {
+	if baseDomain == "" {
+		baseDomain = DefaultBaseDomain
+	}
+	return "https://api." + baseDomain
+}
+
+// RTBaseURL returns the full real-time stats base URL for a given base domain.
+func RTBaseURL(baseDomain string) string {
+	if baseDomain == "" {
+		baseDomain = DefaultBaseDomain
+	}
+	return "https://rt." + baseDomain
+}
+
 // HTTPClient is a consumer contract for components in this package.
 // It models a concrete http.Client.
 type HTTPClient interface {

--- a/pkg/api/datacenter_cache.go
+++ b/pkg/api/datacenter_cache.go
@@ -31,6 +31,7 @@ type Coördinates struct {
 type DatacenterCache struct {
 	client  HTTPClient
 	token   string
+	baseURL string
 	enabled bool
 
 	mtx sync.Mutex
@@ -39,10 +40,14 @@ type DatacenterCache struct {
 
 // NewDatacenterCache returns an empty cache of datacenter metadata. Use the
 // Refresh method to update the cache.
-func NewDatacenterCache(client HTTPClient, token string, enabled bool) *DatacenterCache {
+func NewDatacenterCache(client HTTPClient, token, baseURL string, enabled bool) *DatacenterCache {
+	if baseURL == "" {
+		baseURL = BaseURL("")
+	}
 	return &DatacenterCache{
 		client:  client,
 		token:   token,
+		baseURL: baseURL,
 		enabled: enabled,
 	}
 }
@@ -52,7 +57,7 @@ func (c *DatacenterCache) Refresh(ctx context.Context) error {
 	if !c.enabled {
 		return nil
 	}
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.fastly.com/datacenters", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/datacenters", nil)
 	if err != nil {
 		return fmt.Errorf("error constructing API datacenters request: %w", err)
 	}

--- a/pkg/api/datacenter_cache_test.go
+++ b/pkg/api/datacenter_cache_test.go
@@ -38,7 +38,7 @@ func TestDatacenterCache(t *testing.T) {
 			var (
 				ctx    = context.Background()
 				client = testcase.client
-				cache  = api.NewDatacenterCache(client, "irrelevant token", true)
+				cache  = api.NewDatacenterCache(client, "irrelevant token", "", true)
 			)
 
 			if want, have := testcase.wantErr, cache.Refresh(ctx); !cmp.Equal(want, have) {

--- a/pkg/api/dicitonary_info_cache_test.go
+++ b/pkg/api/dicitonary_info_cache_test.go
@@ -15,7 +15,7 @@ func TestDictionaryInfoCache(t *testing.T) {
 	t.Parallel()
 
 	svcClient := fixedResponseClient{code: 200, response: serviceResponseForDictionaryInfo}
-	serviceCache := api.NewServiceCache(svcClient, "irrelevant_token")
+	serviceCache := api.NewServiceCache(svcClient, "irrelevant_token", "")
 	serviceCache.Refresh(context.Background())
 
 	for _, testcase := range []struct {
@@ -73,7 +73,7 @@ func TestDictionaryInfoCache(t *testing.T) {
 			var (
 				ctx    = context.Background()
 				client = testcase.client
-				cache  = api.NewDictionaryInfoCache(client, "irrelevant token", log.NewNopLogger(), serviceCache, true)
+				cache  = api.NewDictionaryInfoCache(client, "irrelevant token", "", log.NewNopLogger(), serviceCache, true)
 			)
 
 			if want, have := testcase.wantErr, cache.Refresh(ctx); !cmp.Equal(want, have) {

--- a/pkg/api/dictionary_info_cache.go
+++ b/pkg/api/dictionary_info_cache.go
@@ -34,6 +34,7 @@ type dictionaryResp struct {
 type DictionaryInfoCache struct {
 	client       HTTPClient
 	token        string
+	baseURL      string
 	logger       log.Logger
 	serviceCache *ServiceCache
 	enabled      bool
@@ -59,13 +60,17 @@ type Dictionary struct {
 
 // NewDictionaryInfoCache returns an empty cache of dictionary metadata. Use the
 // Refresh method to update the cache.
-func NewDictionaryInfoCache(client HTTPClient, token string, logger log.Logger, serviceCache *ServiceCache, enabled bool) *DictionaryInfoCache {
+func NewDictionaryInfoCache(client HTTPClient, token, baseURL string, logger log.Logger, serviceCache *ServiceCache, enabled bool) *DictionaryInfoCache {
+	if baseURL == "" {
+		baseURL = BaseURL("")
+	}
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	return &DictionaryInfoCache{
 		client:       client,
 		token:        token,
+		baseURL:      baseURL,
 		logger:       log.With(logger, "component", "dictionary-info"),
 		serviceCache: serviceCache,
 		enabled:      enabled,
@@ -201,7 +206,7 @@ func (c *DictionaryInfoCache) req(ctx context.Context, method, url string) (*htt
 }
 
 func (c *DictionaryInfoCache) listDictionaries(ctx context.Context, serviceID string, version int) ([]dictionaryResp, error) {
-	u := fmt.Sprintf("https://api.fastly.com/service/%s/version/%d/dictionary", serviceID, version)
+	u := fmt.Sprintf("%s/service/%s/version/%d/dictionary", c.baseURL, serviceID, version)
 	req, err := c.req(ctx, http.MethodGet, u)
 	if err != nil {
 		return nil, err
@@ -223,7 +228,7 @@ func (c *DictionaryInfoCache) listDictionaries(ctx context.Context, serviceID st
 }
 
 func (c *DictionaryInfoCache) getDictionaryInfo(ctx context.Context, serviceID string, version int, dictID string) (dictionaryInfo, error) {
-	u := fmt.Sprintf("https://api.fastly.com/service/%s/version/%d/dictionary/%s/info", serviceID, version, dictID)
+	u := fmt.Sprintf("%s/service/%s/version/%d/dictionary/%s/info", c.baseURL, serviceID, version, dictID)
 	req, err := c.req(ctx, http.MethodGet, u)
 	if err != nil {
 		return dictionaryInfo{}, err

--- a/pkg/api/product_cache.go
+++ b/pkg/api/product_cache.go
@@ -38,9 +38,10 @@ type Product struct {
 // ProductCache fetches product information from the Fastly Product Entitlement API
 // and stores results in a local cache.
 type ProductCache struct {
-	client HTTPClient
-	token  string
-	logger log.Logger
+	client  HTTPClient
+	token   string
+	baseURL string
+	logger  log.Logger
 
 	mtx      sync.Mutex
 	products map[string]bool
@@ -48,10 +49,14 @@ type ProductCache struct {
 
 // NewProductCache returns an empty cache of Product information. Use the Refresh method
 // to populate with data.
-func NewProductCache(client HTTPClient, token string, logger log.Logger) *ProductCache {
+func NewProductCache(client HTTPClient, token, baseURL string, logger log.Logger) *ProductCache {
+	if baseURL == "" {
+		baseURL = BaseURL("")
+	}
 	return &ProductCache{
 		client:   client,
 		token:    token,
+		baseURL:  baseURL,
 		logger:   logger,
 		products: make(map[string]bool),
 	}
@@ -63,7 +68,7 @@ func (p *ProductCache) Refresh(ctx context.Context) error {
 		if product == ProductDefault {
 			continue
 		}
-		uri := fmt.Sprintf("https://api.fastly.com/entitled-products/%s", product)
+		uri := fmt.Sprintf("%s/entitled-products/%s", p.baseURL, product)
 
 		req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 		if err != nil {

--- a/pkg/api/product_cache_test.go
+++ b/pkg/api/product_cache_test.go
@@ -38,7 +38,7 @@ func TestProductCache(t *testing.T) {
 			var (
 				ctx    = context.Background()
 				client = testcase.client
-				cache  = api.NewProductCache(client, "irrelevant token", log.NewNopLogger())
+				cache  = api.NewProductCache(client, "irrelevant token", "", log.NewNopLogger())
 			)
 
 			// err

--- a/pkg/api/service_cache.go
+++ b/pkg/api/service_cache.go
@@ -30,8 +30,9 @@ type Service struct {
 // ServiceCache polls api.fastly.com/service to keep metadata about
 // one or more service IDs up-to-date.
 type ServiceCache struct {
-	client HTTPClient
-	token  string
+	client  HTTPClient
+	token   string
+	baseURL string
 
 	serviceIDs stringSet
 	nameFilter filter.Filter
@@ -45,11 +46,15 @@ type ServiceCache struct {
 // NewServiceCache returns an empty cache of service metadata. By default, it
 // will fetch metadata about all services available to the provided token. Use
 // options to restrict which services the cache should manage.
-func NewServiceCache(client HTTPClient, token string, options ...ServiceCacheOption) *ServiceCache {
+func NewServiceCache(client HTTPClient, token, baseURL string, options ...ServiceCacheOption) *ServiceCache {
+	if baseURL == "" {
+		baseURL = BaseURL("")
+	}
 	c := &ServiceCache{
-		client: client,
-		token:  token,
-		logger: log.NewNopLogger(),
+		client:  client,
+		token:   token,
+		baseURL: baseURL,
+		logger:  log.NewNopLogger(),
 	}
 	for _, option := range options {
 		option(c)
@@ -96,7 +101,7 @@ func (c *ServiceCache) Refresh(ctx context.Context) error {
 	begin := time.Now()
 
 	var (
-		uri     = fmt.Sprintf("https://api.fastly.com/service?page=1&per_page=%d&filter%%5Binclude_versions%%5D=false", maxServicePageSize)
+		uri     = fmt.Sprintf("%s/service?page=1&per_page=%d&filter%%5Binclude_versions%%5D=false", c.baseURL, maxServicePageSize)
 		total   = 0
 		nextgen = map[string]Service{}
 	)
@@ -126,7 +131,8 @@ func (c *ServiceCache) Refresh(ctx context.Context) error {
 		total += len(response)
 
 		for _, s := range response {
-			debug := level.Debug(log.With(c.logger,
+			debug := level.Debug(log.With(
+				c.logger,
 				"service_id", s.ID,
 				"service_name", s.Name,
 				"service_version", s.Version,

--- a/pkg/api/service_cache_test.go
+++ b/pkg/api/service_cache_test.go
@@ -122,7 +122,7 @@ func TestServiceCache(t *testing.T) {
 			var (
 				ctx    = context.Background()
 				client = fixedResponseClient{code: 200, response: serviceResponseLarge}
-				cache  = api.NewServiceCache(client, "irrelevant_token", testcase.options...)
+				cache  = api.NewServiceCache(client, "irrelevant_token", "", testcase.options...)
 			)
 			if err := cache.Refresh(ctx); err != nil {
 				t.Fatal(err)
@@ -167,7 +167,7 @@ func TestServiceCachePagination(t *testing.T) {
 	var (
 		ctx    = context.Background()
 		client = paginatedResponseClient{responses}
-		cache  = api.NewServiceCache(client, "irrelevant_token")
+		cache  = api.NewServiceCache(client, "irrelevant_token", "")
 	)
 
 	if err := cache.Refresh(ctx); err != nil {

--- a/pkg/api/token.go
+++ b/pkg/api/token.go
@@ -12,17 +12,22 @@ import (
 
 // TokenRecorder requests api.fastly.com/tokens/self once and sets a gauge metric
 type TokenRecorder struct {
-	client HTTPClient
-	token  string
-	metric *prometheus.GaugeVec
+	client  HTTPClient
+	token   string
+	baseURL string
+	metric  *prometheus.GaugeVec
 }
 
 // NewTokenRecorder returns an empty token recorder. Use the
 // Set method to get token data and set the gauge metric.
-func NewTokenRecorder(client HTTPClient, token string) *TokenRecorder {
+func NewTokenRecorder(client HTTPClient, token, baseURL string) *TokenRecorder {
+	if baseURL == "" {
+		baseURL = BaseURL("")
+	}
 	return &TokenRecorder{
-		client: client,
-		token:  token,
+		client:  client,
+		token:   token,
+		baseURL: baseURL,
 	}
 }
 
@@ -59,7 +64,7 @@ type token struct {
 }
 
 func (t *TokenRecorder) getToken(ctx context.Context) (*token, error) {
-	uri := "https://api.fastly.com/tokens/self"
+	uri := t.baseURL + "/tokens/self"
 
 	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 	if err != nil {

--- a/pkg/api/token_test.go
+++ b/pkg/api/token_test.go
@@ -15,7 +15,7 @@ func TestTokenMetric(t *testing.T) {
 		namespace = "fastly"
 		subsystem = "rt"
 	)
-	client := api.NewTokenRecorder(fixedResponseClient{code: http.StatusOK, response: tokenReponseExpiresAt}, "")
+	client := api.NewTokenRecorder(fixedResponseClient{code: http.StatusOK, response: tokenReponseExpiresAt}, "", "")
 	gatherer, _ := client.Gatherer(namespace, subsystem)
 	client.Set(context.Background())
 
@@ -35,7 +35,7 @@ func TestTokenMetricWithoutExpiration(t *testing.T) {
 		namespace = "fastly"
 		subsystem = "rt"
 	)
-	client := api.NewTokenRecorder(fixedResponseClient{code: http.StatusOK, response: tokenReponseNoExpiry}, "")
+	client := api.NewTokenRecorder(fixedResponseClient{code: http.StatusOK, response: tokenReponseNoExpiry}, "", "")
 	gatherer, _ := client.Gatherer(namespace, subsystem)
 	client.Set(context.Background())
 

--- a/pkg/rt/common_test.go
+++ b/pkg/rt/common_test.go
@@ -187,7 +187,7 @@ type countingRealtimeClient struct {
 }
 
 func (c *countingRealtimeClient) Do(req *http.Request) (*http.Response, error) {
-	atomic.AddUint64(&(c.served), 1)
+	atomic.AddUint64(&c.served, 1)
 	return fixedResponseClient{c.code, c.response}.Do(req)
 }
 

--- a/pkg/rt/subscriber.go
+++ b/pkg/rt/subscriber.go
@@ -38,6 +38,7 @@ type Subscriber struct {
 	client        HTTPClient
 	token         string
 	serviceID     string
+	baseURL       string
 	provider      MetadataProvider
 	metrics       *prom.Metrics
 	postprocess   func()
@@ -79,6 +80,12 @@ func WithAggregateOnly(aggregateOnly bool) SubscriberOption {
 	return func(s *Subscriber) { s.aggregateOnly = aggregateOnly }
 }
 
+// WithBaseURL sets the base URL for the real-time stats API.
+// By default, https://rt.fastly.com is used.
+func WithBaseURL(u string) SubscriberOption {
+	return func(s *Subscriber) { s.baseURL = u }
+}
+
 // NewSubscriber returns a ready-to-use subscriber. Callers must be sure to
 // invoke the Run method of the returned subscriber in order to actually update
 // any metrics.
@@ -87,6 +94,7 @@ func NewSubscriber(client HTTPClient, token, serviceID string, metrics *prom.Met
 		client:      client,
 		token:       token,
 		serviceID:   serviceID,
+		baseURL:     "https://rt.fastly.com",
 		metrics:     metrics,
 		provider:    nopMetadataProvider{},
 		postprocess: func() {},
@@ -194,7 +202,7 @@ func (s *Subscriber) queryRealtime(ctx context.Context, ts uint64) (currentName 
 
 	// rt.fastly.com blocks until it has data to return.
 	// It's safe to call in a (single-threaded!) hot loop.
-	u := fmt.Sprintf("https://rt.fastly.com/v1/channel/%s/ts/%d", url.QueryEscape(s.serviceID), ts)
+	u := fmt.Sprintf("%s/v1/channel/%s/ts/%d", s.baseURL, url.QueryEscape(s.serviceID), ts)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return name, apiResultError, 0, ts, fmt.Errorf("error constructing real-time stats API request: %w", err)
@@ -258,7 +266,7 @@ func (s *Subscriber) queryOrigins(ctx context.Context, ts uint64) (currentName s
 
 	// rt.fastly.com blocks until it has data to return.
 	// It's safe to call in a (single-threaded!) hot loop.
-	u := fmt.Sprintf("https://rt.fastly.com/v1/origins/%s/ts/%d", url.QueryEscape(s.serviceID), ts)
+	u := fmt.Sprintf("%s/v1/origins/%s/ts/%d", s.baseURL, url.QueryEscape(s.serviceID), ts)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return name, apiResultError, 0, ts, fmt.Errorf("error constructing origins API request: %w", err)
@@ -322,7 +330,7 @@ func (s *Subscriber) queryDomains(ctx context.Context, ts uint64) (currentName s
 
 	// rt.fastly.com blocks until it has data to return.
 	// It's safe to call in a (single-threaded!) hot loop.
-	u := fmt.Sprintf("https://rt.fastly.com/v1/domains/%s/ts/%d", url.QueryEscape(s.serviceID), ts)
+	u := fmt.Sprintf("%s/v1/domains/%s/ts/%d", s.baseURL, url.QueryEscape(s.serviceID), ts)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return name, apiResultError, 0, ts, fmt.Errorf("error constructing domains API request: %w", err)
@@ -427,7 +435,7 @@ func (s *Subscriber) rtDelay() time.Duration {
 		s.rtDelayCount = maxDelayCount
 	}
 
-	return time.Duration(cube(s.rtDelayCount)+((rand.Intn(10)+1)*(s.rtDelayCount))) * time.Second
+	return time.Duration(cube(s.rtDelayCount)+((rand.Intn(10)+1)*s.rtDelayCount)) * time.Second
 }
 
 func (s *Subscriber) oiDelay() time.Duration {
@@ -436,7 +444,7 @@ func (s *Subscriber) oiDelay() time.Duration {
 		s.oiDelayCount = maxDelayCount
 	}
 
-	return time.Duration(cube(s.oiDelayCount)+((rand.Intn(10)+1)*(s.oiDelayCount))) * time.Second
+	return time.Duration(cube(s.oiDelayCount)+((rand.Intn(10)+1)*s.oiDelayCount)) * time.Second
 }
 
 func (s *Subscriber) diDelay() time.Duration {
@@ -445,7 +453,7 @@ func (s *Subscriber) diDelay() time.Duration {
 		s.diDelayCount = maxDelayCount
 	}
 
-	return time.Duration(cube(s.diDelayCount)+((rand.Intn(10)+1)*(s.diDelayCount))) * time.Second
+	return time.Duration(cube(s.diDelayCount)+((rand.Intn(10)+1)*s.diDelayCount)) * time.Second
 }
 
 func cube(i int) int {


### PR DESCRIPTION
## Summary

Add support for a single `FASTLY_BASE_URL` environment variable to override the default Fastly base domain (`fastly.com`). The API and RT URLs are derived as subdomains:

- API: `https://api.{FASTLY_BASE_URL}`
- RT:  `https://rt.{FASTLY_BASE_URL}`

For example, setting `FASTLY_BASE_URL=staging.fastly.net` would route API calls to `https://api.staging.fastly.net` and real-time stats to `https://rt.staging.fastly.net`.

When unset, the existing defaults (`fastly.com`) are used — fully backward compatible.

## Motivation

Useful for testing against staging environments, local development proxies, or alternative API endpoints without modifying code.

## Changes

- Added `DefaultBaseDomain` constant and `APIBaseURL()`/`RTBaseURL()` helper functions in `pkg/api/common.go`
- Added `baseURL` field to all API cache structs and the RT subscriber
- Added `rt.WithBaseURL()` subscriber option
- Updated constructors to accept a `baseURL` parameter (empty string = default)
- Read `FASTLY_BASE_URL` in `main.go` and derive both URLs from it
- Updated all tests to pass the new parameter